### PR TITLE
Bound tracking export size and unify post-epoch logging across training backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ python scripts/hydride_benchmark_suite.py --config configs/hydride/benchmark_sui
 - Per-run `train.log` / `eval.log` are written continuously while commands execute. Optional suite YAML watchdog keys (`command_idle_timeout_seconds`, `command_wall_timeout_seconds`) can auto-terminate stuck runs and continue the campaign.
 - Training now emits explicit `VAL_START/VAL_PROGRESS/VAL_END`, `TRACK_EXPORT_*`, `EPOCH_HISTORY_WRITE_*`, `CKPT_SAVE_*`, and `REPORT_UPDATE_*` markers so post-epoch hangs can be pinpointed to exact operations in logs.
 - Validation/post-epoch phases emit heartbeat logs (default every 30s via `post_epoch_heartbeat_seconds`) to reduce false watchdog idle kills during long I/O.
+- Tracked validation export now applies the same validation input-size policy (including resize/letterbox + divisible padding) used by dataloaders, records raw/preprocessed shapes, and bounds panel size via `tracking_max_vis_width` / `tracking_max_vis_height` so wide images do not cause long silent post-epoch stalls.
 - Quick verification: run a 1-epoch train (`microseg-cli train ... --set epochs=1`) and confirm the markers above appear in order; if a stall occurs, the last marker identifies the blocked step.
 
 ## Beginner End-To-End Workflow

--- a/src/microseg/training/pixel_classifier.py
+++ b/src/microseg/training/pixel_classifier.py
@@ -170,11 +170,19 @@ class PixelClassifierTrainer:
             tol=1e-3,
             random_state=int(config.seed),
         )
+        logger.info("VAL_START | backend=pixel_classifier epoch=0 note=not_applicable")
+        logger.info("VAL_END | backend=pixel_classifier epoch=0 note=not_applicable")
+        logger.info("METRIC_REDUCTION_START | backend=pixel_classifier epoch=0")
+        logger.info("METRIC_REDUCTION_END | backend=pixel_classifier epoch=0")
+        logger.info("TRACK_EXPORT_START | backend=pixel_classifier epoch=0 selected=0 note=unsupported")
+        logger.info("TRACK_EXPORT_END | backend=pixel_classifier epoch=0 selected=0 elapsed=00:00:00")
         clf.fit(x, y)
 
         model_path = output_dir / "pixel_classifier.joblib"
         metadata_path = output_dir / "training_manifest.json"
+        logger.info("CKPT_SAVE_START | backend=pixel_classifier path=%s", model_path)
         joblib.dump(clf, model_path)
+        logger.info("CKPT_SAVE_END | backend=pixel_classifier path=%s size_bytes=%d", model_path, int(model_path.stat().st_size))
 
         payload = {
             "schema_version": "microseg.pixel_classifier.v1",
@@ -185,7 +193,9 @@ class PixelClassifierTrainer:
             "classes": [int(v) for v in np.unique(y).tolist()],
             "model_file": model_path.name,
         }
+        logger.info("REPORT_UPDATE_START | backend=pixel_classifier path=%s", metadata_path)
         metadata_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        logger.info("REPORT_UPDATE_END | backend=pixel_classifier path=%s", metadata_path)
 
         return {
             "model_path": str(model_path),

--- a/src/microseg/training/torch_pixel_classifier.py
+++ b/src/microseg/training/torch_pixel_classifier.py
@@ -180,7 +180,15 @@ class TorchPixelClassifierTrainer:
 
         n = x.shape[0]
         batch_size = max(1, int(config.batch_size))
-        for _epoch in range(int(config.epochs)):
+        logger.info("VAL_START | backend=torch_pixel epoch=0 note=not_applicable")
+        logger.info("VAL_END | backend=torch_pixel epoch=0 note=not_applicable")
+        logger.info("METRIC_REDUCTION_START | backend=torch_pixel epoch=0")
+        logger.info("METRIC_REDUCTION_END | backend=torch_pixel epoch=0")
+        logger.info("TRACK_EXPORT_START | backend=torch_pixel epoch=0 selected=0 note=unsupported")
+        logger.info("TRACK_EXPORT_END | backend=torch_pixel epoch=0 selected=0 elapsed=00:00:00")
+
+        for epoch_idx in range(int(config.epochs)):
+            logger.info("EPOCH_TRAIN_START | backend=torch_pixel epoch=%d/%d", epoch_idx + 1, int(config.epochs))
             perm = torch.randperm(n, device=device)
             for start in range(0, n, batch_size):
                 idx = perm[start:start + batch_size]
@@ -189,6 +197,7 @@ class TorchPixelClassifierTrainer:
                 opt.zero_grad()
                 loss.backward()
                 opt.step()
+            logger.info("EPOCH_TRAIN_END | backend=torch_pixel epoch=%d/%d", epoch_idx + 1, int(config.epochs))
 
         model_path = output_dir / "torch_pixel_classifier.pt"
         manifest_path = output_dir / "training_manifest.json"
@@ -200,7 +209,9 @@ class TorchPixelClassifierTrainer:
             "class_values": [int(v) for v in class_values.tolist()],
             "state_dict": model.state_dict(),
         }
+        logger.info("CKPT_SAVE_START | backend=torch_pixel path=%s", model_path)
         torch.save(checkpoint, model_path)
+        logger.info("CKPT_SAVE_END | backend=torch_pixel path=%s size_bytes=%d", model_path, int(model_path.stat().st_size))
 
         manifest = {
             "schema_version": "microseg.training_manifest.v1",
@@ -214,7 +225,9 @@ class TorchPixelClassifierTrainer:
             "model_file": model_path.name,
             "classes": checkpoint["class_values"],
         }
+        logger.info("REPORT_UPDATE_START | backend=torch_pixel path=%s", manifest_path)
         manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+        logger.info("REPORT_UPDATE_END | backend=torch_pixel path=%s", manifest_path)
 
         return {
             "backend": "torch_pixel",

--- a/src/microseg/training/unet_binary.py
+++ b/src/microseg/training/unet_binary.py
@@ -1347,6 +1347,9 @@ class UNetBinaryTrainingConfig:
     mask_interpolation: str = "nearest"
     require_divisible_by: int = 32
     dataloader_collate: str = "default"
+    tracking_max_vis_width: int = 2048
+    tracking_max_vis_height: int = 2048
+    tracking_png_compress_level: int = 1
 
 
 def _binary_iou_from_logits(logits, targets) -> float:  # noqa: ANN001
@@ -1455,6 +1458,18 @@ def _tracking_panel(image: np.ndarray, gt: np.ndarray, pred: np.ndarray) -> np.n
     pred_rgb = np.stack([pred_u8, pred_u8, pred_u8], axis=2)
     diff_rgb = np.stack([diff_u8, diff_u8, diff_u8], axis=2)
     return np.concatenate([image, gt_rgb, pred_rgb, diff_rgb], axis=1).astype(np.uint8)
+
+
+def _downscale_for_visualization(image: np.ndarray, *, max_height: int, max_width: int) -> np.ndarray:
+    max_h = max(1, int(max_height))
+    max_w = max(1, int(max_width))
+    h, w = int(image.shape[0]), int(image.shape[1])
+    if h <= max_h and w <= max_w:
+        return image
+    scale = min(max_h / max(1, h), max_w / max(1, w))
+    out_h = max(1, int(round(h * scale)))
+    out_w = max(1, int(round(w * scale)))
+    return np.asarray(Image.fromarray(image).resize((out_w, out_h), resample=Image.Resampling.BILINEAR), dtype=np.uint8)
 
 
 def _write_training_html(payload: dict[str, Any], output_path: Path) -> None:
@@ -1949,11 +1964,28 @@ class UNetBinaryTrainer:
                         mode=config.binary_mask_normalization,
                     )
                     gt_bin = (gt > 0).astype(np.uint8)
-                    logger.info("TRACK_SAMPLE_IMAGE_LOAD_END | sample=%s elapsed=%s", img_path.name, _format_seconds(time.perf_counter() - io_start))
+                    raw_hw = (int(image.shape[0]), int(image.shape[1]))
+                    logger.info(
+                        "TRACK_SAMPLE_IMAGE_LOAD_END | sample=%s raw_hw=%s elapsed=%s",
+                        img_path.name,
+                        raw_hw,
+                        _format_seconds(time.perf_counter() - io_start),
+                    )
 
                     prep_start = time.perf_counter()
-                    x = torch.from_numpy((image.astype(np.float32) / 255.0).transpose(2, 0, 1)[None, ...]).to(device)
-                    logger.info("TRACK_SAMPLE_TENSOR_PREP_END | sample=%s elapsed=%s", img_path.name, _format_seconds(time.perf_counter() - prep_start))
+                    x_raw = torch.from_numpy((image.astype(np.float32) / 255.0).transpose(2, 0, 1))
+                    y_raw = torch.from_numpy(gt_bin[None, ...].astype(np.float32))
+                    x_policy, y_policy = apply_input_policy(x_raw, y_raw, val_policy_cfg, is_train=False)
+                    x = x_policy.unsqueeze(0).to(device)
+                    gt_bin = (y_policy.squeeze(0).cpu().numpy() > 0).astype(np.uint8)
+                    image_vis = (np.clip(x_policy.cpu().numpy().transpose(1, 2, 0), 0.0, 1.0) * 255.0).astype(np.uint8)
+                    pre_hw = (int(x_policy.shape[-2]), int(x_policy.shape[-1]))
+                    logger.info(
+                        "TRACK_SAMPLE_TENSOR_PREP_END | sample=%s pre_hw=%s elapsed=%s",
+                        img_path.name,
+                        pre_hw,
+                        _format_seconds(time.perf_counter() - prep_start),
+                    )
 
                     fw_start = time.perf_counter()
                     logits = model(x)
@@ -1963,19 +1995,56 @@ class UNetBinaryTrainer:
                     pred = (torch.sigmoid(logits) > 0.5).to(torch.uint8).cpu().numpy()[0, 0].astype(np.uint8)
                     sample_metrics = _binary_sample_metrics(gt_bin, pred)
                     scientific_metrics = scientific_distance_metrics(gt_bin, pred)
-                    logger.info("TRACK_SAMPLE_POSTPROC_END | sample=%s elapsed=%s", img_path.name, _format_seconds(time.perf_counter() - post_start))
+                    panel = _tracking_panel(image_vis, gt_bin, pred)
+                    panel = _downscale_for_visualization(
+                        panel,
+                        max_height=int(config.tracking_max_vis_height),
+                        max_width=int(config.tracking_max_vis_width),
+                    )
+                    logger.info(
+                        "TRACK_SAMPLE_POSTPROC_END | sample=%s elapsed=%s",
+                        img_path.name,
+                        _format_seconds(time.perf_counter() - post_start),
+                    )
+                    logger.info(
+                        "TRACK_SAMPLE_SHAPES | sample=%s raw=(%d,%d) pre=(%d,%d) gt=%s pred=%s panel=%s",
+                        img_path.name,
+                        raw_hw[0],
+                        raw_hw[1],
+                        pre_hw[0],
+                        pre_hw[1],
+                        tuple(int(v) for v in gt_bin.shape),
+                        tuple(int(v) for v in pred.shape),
+                        tuple(int(v) for v in panel.shape),
+                    )
 
                     stem = img_path.stem
                     panel_path = out_epoch / f"{stem}_panel.png"
                     pred_path = out_epoch / f"{stem}_pred.png"
                     gt_path = out_epoch / f"{stem}_gt.png"
 
+                    heartbeat.force(
+                        "HEARTBEAT | phase=tracking_export_pre_write epoch=%d sample=%d/%d name=%s",
+                        epoch,
+                        sample_idx,
+                        len(selected_pairs),
+                        img_path.name,
+                    )
                     write_start = time.perf_counter()
                     logger.info("TRACK_SAMPLE_FILE_WRITE_START | sample=%s gt=%s pred=%s panel=%s", img_path.name, gt_path, pred_path, panel_path)
-                    Image.fromarray(_tracking_panel(image, gt_bin, pred)).save(panel_path)
-                    Image.fromarray((pred * 255).astype(np.uint8)).save(pred_path)
-                    Image.fromarray((gt_bin * 255).astype(np.uint8)).save(gt_path)
-                    logger.info("TRACK_SAMPLE_FILE_WRITE_END | sample=%s elapsed=%s", img_path.name, _format_seconds(time.perf_counter() - write_start))
+                    png_opts = {"compress_level": max(0, min(9, int(config.tracking_png_compress_level)))}
+                    Image.fromarray(panel).save(panel_path, **png_opts)
+                    Image.fromarray((pred * 255).astype(np.uint8)).save(pred_path, **png_opts)
+                    Image.fromarray((gt_bin * 255).astype(np.uint8)).save(gt_path, **png_opts)
+                    write_elapsed = time.perf_counter() - write_start
+                    logger.info(
+                        "TRACK_SAMPLE_FILE_WRITE_END | sample=%s elapsed=%s size_gt=%d size_pred=%d size_panel=%d",
+                        img_path.name,
+                        _format_seconds(write_elapsed),
+                        int(gt_path.stat().st_size),
+                        int(pred_path.stat().st_size),
+                        int(panel_path.stat().st_size),
+                    )
 
                     records.append(
                         {

--- a/tests/test_phase7_training_reporting.py
+++ b/tests/test_phase7_training_reporting.py
@@ -38,6 +38,12 @@ def _dataset(root: Path) -> Path:
     img_b[:, :14] = 230
     m_b[:, :14] = 1
     _write_pair(ds / "val" / "images", ds / "val" / "masks", "val_111.png", img_b, m_b)
+
+    wide_img = np.zeros((32, 240, 3), dtype=np.uint8)
+    wide_mask = np.zeros((32, 240), dtype=np.uint8)
+    wide_img[:, 100:180, :] = 250
+    wide_mask[:, 100:180] = 1
+    _write_pair(ds / "val" / "images", ds / "val" / "masks", "val_wide.png", wide_img, wide_mask)
     return ds
 
 
@@ -60,10 +66,13 @@ def test_phase7_unet_training_writes_reports_and_tracking_artifacts(tmp_path: Pa
             early_stopping_patience=2,
             checkpoint_every=1,
             val_tracking_samples=2,
-            val_tracking_fixed_samples=("val_000.png",),
+            val_tracking_fixed_samples=("val_000.png", "val_wide.png"),
             val_tracking_seed=5,
             write_html_report=True,
             progress_log_interval_pct=50,
+            input_hw=(32, 32),
+            tracking_max_vis_width=128,
+            tracking_max_vis_height=64,
         )
     )
 
@@ -73,6 +82,11 @@ def test_phase7_unet_training_writes_reports_and_tracking_artifacts(tmp_path: Pa
     assert (out / "epoch_history.jsonl").exists()
     assert (out / "eval_samples" / "epoch_001").exists()
     assert any(p.name.startswith("val_000_") for p in (out / "eval_samples" / "epoch_001").glob("*.png"))
+    wide_panel = out / "eval_samples" / "epoch_001" / "val_wide_panel.png"
+    assert wide_panel.exists()
+    panel_arr = np.asarray(Image.open(wide_panel).convert("RGB"), dtype=np.uint8)
+    assert panel_arr.shape[0] <= 64
+    assert panel_arr.shape[1] <= 128
 
     payload = json.loads((out / "report.json").read_text(encoding="utf-8"))
     assert payload["schema_version"] == "microseg.training_report.v1"
@@ -93,6 +107,8 @@ def test_phase7_unet_training_writes_reports_and_tracking_artifacts(tmp_path: Pa
     assert "VAL_END" in log_text
     assert "TRACK_EXPORT_START" in log_text
     assert "TRACK_EXPORT_END" in log_text
+    assert "TRACK_SAMPLE_SHAPES" in log_text
+    assert "TRACK_SAMPLE_FILE_WRITE_END" in log_text
     assert "EPOCH_HISTORY_WRITE_START" in log_text
     assert "EPOCH_HISTORY_WRITE_END" in log_text
     assert "CKPT_SAVE_START" in log_text


### PR DESCRIPTION
### Motivation
- Prevent long silent post-epoch stalls during tracked validation sample export for very wide images by enforcing the same validation input-size policy and bounding visualization outputs. 
- Improve observability of post-epoch steps so watchdogs and operators can pinpoint slow I/O or CPU-side postprocessing. 
- Ensure consistent verbose eval / post-epoch logging across training backends so markers are grepable and behavior is comparable.

### Description
- UNet tracking export now applies the validation input policy via `apply_input_policy` (reuse of dataloader val policy) so tracked inference runs at a bounded preprocessed resolution rather than native image size. (`src/microseg/training/unet_binary.py`)
- Added config options `tracking_max_vis_width`, `tracking_max_vis_height`, and `tracking_png_compress_level` to cap and tune tracked-panel outputs and reduce expensive writes. (`UNetBinaryTrainingConfig`)
- Implemented `_downscale_for_visualization` and ensure panels are generated from the preprocessed image, then downscaled when exceeding limits, and saved with configurable PNG compression to bound runtime. (`src/microseg/training/unet_binary.py`)
- Added richer per-sample diagnostics and heartbeat logging during tracking export including `TRACK_SAMPLE_IMAGE_LOAD_END` (raw_hw), `TRACK_SAMPLE_TENSOR_PREP_END` (pre_hw), `TRACK_SAMPLE_SHAPES`, `TRACK_SAMPLE_FILE_WRITE_START/END` (elapsed + output sizes), and a pre-write `HEARTBEAT` to avoid long silent intervals. (`src/microseg/training/unet_binary.py`)
- Propagated standardized post-epoch/eval markers to other backends (`torch_pixel_classifier`, `pixel_classifier`) by emitting `VAL_*`, `METRIC_REDUCTION_*`, `TRACK_EXPORT_*`, `CKPT_SAVE_*`, and `REPORT_UPDATE_*` logs (with clear notes when not applicable). (`src/microseg/training/torch_pixel_classifier.py`, `src/microseg/training/pixel_classifier.py`)
- Test and docs updates: extended `tests/test_phase7_training_reporting.py` to include a wide validation image and asserts for bounded panel dimensions and new tracking diagnostics, and added a README note documenting the change. (`tests/test_phase7_training_reporting.py`, `README.md`)

### Testing
- Ran the updated phase-7 test: `PYTHONPATH=. pytest -q tests/test_phase7_training_reporting.py`, which completed successfully (1 passed, 1 warning). 
- Verified bytecode compilation with `python -m compileall src/microseg/training`, which succeeded. 
- Note: an initial `pytest -q tests/test_phase7_training_reporting.py` without `PYTHONPATH=.` failed during collection due to import path resolution, after which tests were rerun with `PYTHONPATH=.`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a165126dc08324b1ac0c3026949d55)