### PR TITLE
Add paired JPG+RGB PNG -> MaDo dataset prep with short-side crop, RGB binarization, QA and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ Unsplit `source/masks` auto-prepare (leakage-aware default + global IDs):
 microseg-cli dataset-prepare --config configs/dataset_prepare.default.yml
 ```
 See [docs/data_preparation.md](docs/data_preparation.md) for the dedicated binary segmentation data preparation subsystem (pairing, binarization, resizing, manifesting, and Oxford/MaDo exports).
+
+Paired JPG + RGB PNG mask to MaDo-style dataset prep:
+```bash
+python scripts/microseg_cli.py prepare_dataset \
+  --config configs/hydride/prepare_dataset.paired_rgb_mask.mado.yml \
+  --input-dir D:/data/hydride_pairs \
+  --output-root D:/data/HydrideData7.0 \
+  --style mado \
+  --target-size 512 \
+  --crop-train random \
+  --crop-eval center \
+  --mask-r-min 200 --mask-g-max 60 --mask-b-max 60 \
+  --seed 42 --train-frac 0.8 --val-frac 0.1
+```
+Use `--dry-run` to validate pairing and inspect planned outputs without writing dataset files.
+
 In debug mode, dataset preparation now also exports raw-vs-binarized mask difference views and emits explicit warnings when raw masks contain values outside expected binary levels (`0/255` by default).
 
 

--- a/configs/data_prep.default.yml
+++ b/configs/data_prep.default.yml
@@ -31,6 +31,12 @@ foreground_values:
 percentile: 90.0
 invert_mask: false
 
+rgb_mask_mode: false
+mask_r_min: 200
+mask_g_max: 60
+mask_b_max: 60
+enforce_gb_thresholds: true
+
 morphology:
   open_kernel: 0
   close_kernel: 0
@@ -41,6 +47,11 @@ target_size:
   - 512
   - 512
 resize_policy: letterbox_pad
+crop_mode_train: random
+crop_mode_eval: center
+progress_log_interval: 20
+qa_report_name: dataset_qa_report.json
+html_report_name: dataset_qa_report.html
 image_pad_mode: constant
 image_pad_value: 0
 image_interpolation: area

--- a/configs/hydride/prepare_dataset.paired_rgb_mask.mado.yml
+++ b/configs/hydride/prepare_dataset.paired_rgb_mask.mado.yml
@@ -1,0 +1,42 @@
+input_dir: data/raw/hydride_pairs
+output_dir: outputs/hydride_dataset
+styles:
+  - mado
+strict_pairing: true
+
+image_extensions:
+  - .jpg
+  - .jpeg
+mask_extensions:
+  - .png
+mask_name_patterns:
+  - "{stem}.png"
+
+rgb_mask_mode: true
+mask_r_min: 200
+mask_g_max: 60
+mask_b_max: 60
+enforce_gb_thresholds: true
+
+invert_mask: false
+morphology:
+  open_kernel: 0
+  close_kernel: 0
+  remove_small_components: 0
+  fill_holes: false
+
+target_size: 512
+resize_policy: short_side_to_target_crop
+crop_mode_train: random
+crop_mode_eval: center
+
+train_pct: 0.8
+val_pct: 0.1
+seed: 42
+
+image_ext: .png
+mask_ext: .png
+mask_foreground_value: 255
+progress_log_interval: 25
+qa_report_name: dataset_qa_report.json
+html_report_name: dataset_qa_report.html

--- a/docs/data_preparation.md
+++ b/docs/data_preparation.md
@@ -15,45 +15,68 @@ It currently targets binary segmentation and is designed to extend to multiclass
 - Config model with YAML loading fallback to in-code dictionary defaults.
 - Default config file: `configs/data_prep.default.yml` (auto-loaded by `prep-dataset` when `--config` is omitted).
 - Pairing with strict/permissive modes and configurable mask naming patterns.
+- **Paired JPG + RGB PNG mask ingestion** (`{stem}.jpg` + `{stem}.png` in the same folder).
 - Binarization modes:
   - `nonzero`
   - `threshold` (`>=T` or `>T`)
   - `value_equals`
   - `otsu`
   - `percentile`
+  - `rgb_mask_mode` (red-channel threshold with optional G/B suppression)
 - Optional morphology: open/close, small-component removal, hole filling.
 - Raw mask quality checks for unexpected non-binary values (default expected values: `0`, `255`).
 - Resizing policies:
-  - `letterbox_pad` (default)
+  - `letterbox_pad`
   - `center_crop`
   - `stretch`
   - `keep_aspect_no_pad`
+  - `short_side_to_target_crop` (scale shortest side to target, then crop)
+- Split-aware crop modes (`crop_mode_train`, `crop_mode_eval`).
 - Multi-format export (`.png`, `.tif/.tiff`) with Pillow TIFF fallback.
 - Deterministic `manifest.json` with split counts, record-level stats, and warnings.
+- Dataset QA artifacts: `dataset_qa_report.json` and `dataset_qa_report.html`.
+- Progress + ETA logging plus `dataset_prepare.log` in output folder.
 - Debug mode subset processing plus inspection artifacts (image/raw mask/binary/difference/overlay/panel).
-- Run-time warnings and manifest warnings for any raw-mask pixels outside expected binary values.
 
 ## CLI Usage
 
 ```bash
 prep-dataset \
-  --input path/to/paired_data \
-  --output outputs/prepared_binary \
-  --style oxford,mado \
-  --config configs/data_prep.default.yml \
+  --input-dir path/to/paired_data \
+  --output-root outputs/prepared_binary \
+  --style mado \
+  --target-size 512 \
+  --crop-train random \
+  --crop-eval center \
+  --mask-r-min 200 \
+  --mask-g-max 60 \
+  --mask-b-max 60 \
   --seed 42
+```
+
+Dry run:
+
+```bash
+python scripts/microseg_cli.py prepare_dataset \
+  --input-dir D:/data/hydride_pairs \
+  --output-root D:/data/HydrideData7.0 \
+  --style mado \
+  --target-size 512 \
+  --crop-train random \
+  --crop-eval center \
+  --mask-r-min 200 \
+  --mask-g-max 60 \
+  --mask-b-max 60 \
+  --seed 42 \
+  --train-frac 0.8 \
+  --val-frac 0.1 \
+  --dry-run
 ```
 
 Python module invocation:
 
 ```bash
 python -m src.microseg.data_preparation.cli --input ... --output ... --debug
-```
-
-Dry run (manifest-only planning):
-
-```bash
-prep-dataset --input ... --output ... --dry-run --style oxford,mado
 ```
 
 ## Programmatic Usage
@@ -65,15 +88,21 @@ from src.microseg.data_preparation.pipeline import DatasetPreparer
 cfg = DatasetPrepConfig.from_dict({
     "input_dir": "data/paired",
     "output_dir": "outputs/prepared",
-    "styles": ["oxford", "mado"],
-    "binarization_mode": "threshold",
-    "threshold": 128,
+    "styles": ["mado"],
+    "rgb_mask_mode": True,
+    "mask_r_min": 200,
+    "mask_g_max": 60,
+    "mask_b_max": 60,
+    "resize_policy": "short_side_to_target_crop",
+    "target_size": 512,
+    "crop_mode_train": "random",
+    "crop_mode_eval": "center",
 })
 result = DatasetPreparer(cfg).run()
 print(result.manifest_path)
 ```
 
-## Manifest Fields
+## Manifest / QA Fields
 
 `manifest.json` includes:
 
@@ -84,8 +113,15 @@ print(result.manifest_path)
 - per-record source paths and export paths
 - original/output shapes
 - mask stats (raw/binary unique values, foreground count/ratio)
-- non-binary raw-value diagnostics (unexpected values, affected pixel count/ratio, warning text)
 - item-level and overall warnings summary
+
+`dataset_qa_report.json` includes:
+
+- pair/missing diagnostics
+- split counts
+- read failure list
+- aggregate foreground coverage stats
+- elapsed stage timing
 
 ## Extending To Multiclass
 

--- a/scripts/microseg_cli.py
+++ b/scripts/microseg_cli.py
@@ -22,6 +22,8 @@ from src.microseg.app.hpc_ga import (
     summarize_feedback_sources,
 )
 from src.microseg.corrections import CorrectionDatasetPackager
+from src.microseg.data_preparation.config import DatasetPrepConfig
+from src.microseg.data_preparation.pipeline import DatasetPreparer
 from src.microseg.dataops import (
     CorrectionSplitConfig,
     DatasetPrepareConfig,
@@ -608,6 +610,45 @@ def _dataset_prepare(args: argparse.Namespace) -> int:
     return 0
 
 
+
+def _prepare_dataset_paired(args: argparse.Namespace) -> int:
+    cfg = resolve_config(args.config, args.set)
+    input_dir = args.input_dir or cfg.get("input_dir")
+    if not input_dir:
+        raise ValueError("input directory is required (--input-dir or config:input_dir)")
+    output_root = args.output_root or cfg.get("output_dir") or cfg.get("output_root")
+    if not output_root:
+        raise ValueError("output root is required (--output-root or config:output_dir)")
+
+    resolved = DatasetPrepConfig.from_dict({
+        **cfg,
+        "input_dir": str(input_dir),
+        "output_dir": str(output_root),
+        "styles": [part.strip() for part in str(args.style or cfg.get("style", "mado")).split(",") if part.strip()],
+        "train_pct": float(cfg.get("train_pct", args.train_frac)),
+        "val_pct": float(cfg.get("val_pct", args.val_frac)),
+        "seed": int(cfg.get("seed", args.seed)),
+        "dry_run": bool(cfg.get("dry_run", args.dry_run)),
+        "target_size": int(cfg.get("target_size", args.target_size)),
+        "resize_policy": str(cfg.get("resize_policy", "short_side_to_target_crop")),
+        "crop_mode_train": str(cfg.get("crop_mode_train", args.crop_train)),
+        "crop_mode_eval": str(cfg.get("crop_mode_eval", args.crop_eval)),
+        "rgb_mask_mode": bool(cfg.get("rgb_mask_mode", True)),
+        "mask_r_min": int(cfg.get("mask_r_min", args.mask_r_min)),
+        "mask_g_max": int(cfg.get("mask_g_max", args.mask_g_max)),
+        "mask_b_max": int(cfg.get("mask_b_max", args.mask_b_max)),
+        "image_extensions": cfg.get("image_extensions", [".jpg", ".jpeg"]),
+        "mask_extensions": cfg.get("mask_extensions", [".png"]),
+        "mask_name_patterns": cfg.get("mask_name_patterns", ["{stem}.png"]),
+    })
+
+    result = DatasetPreparer(resolved).run()
+    print(f"prepared dataset: {output_root}")
+    print(f"dataset directory for training: {Path(output_root) / 'mado'}")
+    print(f"manifest: {result.manifest_path}")
+    print(f"split counts: {result.split_counts}")
+    return 0
+
 def _hpc_ga_generate(args: argparse.Namespace) -> int:
     cfg = resolve_config(args.config, args.set)
     dataset_dir = args.dataset_dir or cfg.get("dataset_dir")
@@ -1023,6 +1064,24 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     prep.add_argument("--class-map-path", type=str, default="")
     prep.set_defaults(handler=_dataset_prepare)
+
+    paired = sub.add_parser("prepare_dataset", help="Prepare paired JPG + RGB PNG masks into MaDo/Oxford layout")
+    paired.add_argument("--config", type=str, help="YAML config path")
+    paired.add_argument("--set", action="append", default=[], help="Override key=value")
+    paired.add_argument("--input-dir", type=str, help="Input paired folder containing {stem}.jpg + {stem}.png")
+    paired.add_argument("--output-root", type=str, help="Output dataset root")
+    paired.add_argument("--style", type=str, default="mado", help="Comma-separated styles")
+    paired.add_argument("--target-size", type=int, default=512)
+    paired.add_argument("--crop-train", choices=["center", "random"], default="random")
+    paired.add_argument("--crop-eval", choices=["center", "random"], default="center")
+    paired.add_argument("--mask-r-min", type=int, default=200)
+    paired.add_argument("--mask-g-max", type=int, default=60)
+    paired.add_argument("--mask-b-max", type=int, default=60)
+    paired.add_argument("--seed", type=int, default=42)
+    paired.add_argument("--train-frac", type=float, default=0.8)
+    paired.add_argument("--val-frac", type=float, default=0.1)
+    paired.add_argument("--dry-run", action="store_true")
+    paired.set_defaults(handler=_prepare_dataset_paired)
 
     hpc_ga = sub.add_parser("hpc-ga-generate", help="Generate GA-planned HPC job bundle")
     hpc_ga.add_argument("--config", type=str, help="YAML config path")

--- a/src/microseg/data_preparation/binarization.py
+++ b/src/microseg/data_preparation/binarization.py
@@ -16,6 +16,8 @@ class MaskBinarizer:
         self.cfg = cfg
 
     def apply(self, raw_mask: np.ndarray) -> tuple[np.ndarray, dict[str, object]]:
+        if self.cfg.rgb_mask_mode:
+            return self._apply_rgb_threshold(raw_mask)
         gray = self._to_gray(raw_mask)
         unique_raw = sorted(np.unique(gray).astype(int).tolist())
         expected = sorted({int(v) for v in self.cfg.expected_raw_binary_values})
@@ -66,6 +68,48 @@ class MaskBinarizer:
         stats["unique_binary_values"] = sorted(np.unique(cleaned).astype(int).tolist())
         stats["fg_pixel_count"] = int(cleaned.sum())
         stats["fg_ratio"] = float(cleaned.mean())
+        return cleaned.astype(np.uint8), stats
+
+    def _apply_rgb_threshold(self, raw_mask: np.ndarray) -> tuple[np.ndarray, dict[str, object]]:
+        warnings: list[str] = []
+        if raw_mask.ndim == 2:
+            warnings.append("mask is grayscale but rgb_mask_mode=true; falling back to grayscale threshold on red/min channel")
+            red = raw_mask
+            green = np.zeros_like(raw_mask)
+            blue = np.zeros_like(raw_mask)
+        elif raw_mask.ndim == 3 and raw_mask.shape[2] >= 3:
+            blue = raw_mask[:, :, 0]
+            green = raw_mask[:, :, 1]
+            red = raw_mask[:, :, 2]
+        else:
+            raise ValueError(f"unsupported mask shape for RGB binarization: {raw_mask.shape}")
+
+        red_sel = red >= int(self.cfg.mask_r_min)
+        if self.cfg.enforce_gb_thresholds:
+            binary = red_sel & (green <= int(self.cfg.mask_g_max)) & (blue <= int(self.cfg.mask_b_max))
+        else:
+            binary = red_sel
+        if self.cfg.invert_mask:
+            binary = ~binary
+
+        cleaned = self._morphology(binary.astype(np.uint8))
+        stats: dict[str, object] = {
+            "mode": "rgb_threshold",
+            "thresholds": {
+                "mask_r_min": int(self.cfg.mask_r_min),
+                "mask_g_max": int(self.cfg.mask_g_max),
+                "mask_b_max": int(self.cfg.mask_b_max),
+                "enforce_gb_thresholds": bool(self.cfg.enforce_gb_thresholds),
+            },
+            "warnings": warnings,
+            "raw_mask_channels": 1 if raw_mask.ndim == 2 else int(raw_mask.shape[2]),
+            "red_unique_values": sorted(np.unique(red).astype(int).tolist())[:256],
+            "green_unique_values": sorted(np.unique(green).astype(int).tolist())[:256],
+            "blue_unique_values": sorted(np.unique(blue).astype(int).tolist())[:256],
+            "unique_binary_values": sorted(np.unique(cleaned).astype(int).tolist()),
+            "fg_pixel_count": int(cleaned.sum()),
+            "fg_ratio": float(cleaned.mean()),
+        }
         return cleaned.astype(np.uint8), stats
 
     def _morphology(self, binary: np.ndarray) -> np.ndarray:

--- a/src/microseg/data_preparation/cli.py
+++ b/src/microseg/data_preparation/cli.py
@@ -12,23 +12,35 @@ from src.microseg.data_preparation.pipeline import DatasetPreparer
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Prepare segmentation datasets (binary masks).")
-    parser.add_argument("--input", required=True, dest="input_dir")
-    parser.add_argument("--output", required=True, dest="output_dir")
+    parser.add_argument("--input", "--input-dir", required=True, dest="input_dir")
+    parser.add_argument("--output", "--output-dir", "--output-root", required=True, dest="output_dir")
     parser.add_argument("--style", default="oxford,mado", help="Comma-separated styles: oxford,mado")
     parser.add_argument("--config", default=None, help="Optional YAML config. Defaults to configs/data_prep.default.yml when present.")
     parser.add_argument("--debug", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--seed", type=int, default=42)
-    parser.add_argument("--train-pct", type=float, default=0.8)
-    parser.add_argument("--val-pct", type=float, default=0.1)
+    parser.add_argument("--train-pct", "--train-frac", type=float, default=0.8)
+    parser.add_argument("--val-pct", "--val-frac", type=float, default=0.1)
     parser.add_argument("--skip-sanity", action="store_true")
     parser.add_argument("--debug-limit", type=int, default=100)
     parser.add_argument("--num-debug", type=int, default=8)
+    parser.add_argument("--target-size", type=int, default=512)
+    parser.add_argument("--crop-train", choices=["center", "random"], default="random")
+    parser.add_argument("--crop-eval", choices=["center", "random"], default="center")
+    parser.add_argument("--mask-r-min", type=int, default=200)
+    parser.add_argument("--mask-g-max", type=int, default=60)
+    parser.add_argument("--mask-b-max", type=int, default=60)
+    parser.add_argument("--rgb-mask-mode", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--progress-log-interval", type=int, default=20)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s | %(levelname)s | %(message)s")
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        handlers=[logging.StreamHandler()],
+    )
     args = build_parser().parse_args(argv)
     default_config_path = Path(__file__).resolve().parents[3] / "configs" / "data_prep.default.yml"
     resolved_config_path: str | None = args.config
@@ -45,6 +57,15 @@ def main(argv: list[str] | None = None) -> int:
         "train_pct": args.train_pct,
         "val_pct": args.val_pct,
         "skip_sanity": args.skip_sanity,
+        "target_size": [args.target_size, args.target_size],
+        "resize_policy": "short_side_to_target_crop",
+        "crop_mode_train": args.crop_train,
+        "crop_mode_eval": args.crop_eval,
+        "rgb_mask_mode": bool(args.rgb_mask_mode),
+        "mask_r_min": args.mask_r_min,
+        "mask_g_max": args.mask_g_max,
+        "mask_b_max": args.mask_b_max,
+        "progress_log_interval": args.progress_log_interval,
         "debug": {
             "enabled": args.debug,
             "limit_pairs": args.debug_limit,
@@ -52,8 +73,14 @@ def main(argv: list[str] | None = None) -> int:
         },
     }
     cfg = DatasetPrepConfig.from_yaml_or_default(resolved_config_path, fallback)
+    output_dir = Path(cfg.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    file_handler = logging.FileHandler(output_dir / "dataset_prepare.log", encoding="utf-8")
+    file_handler.setFormatter(logging.Formatter("%(asctime)s | %(levelname)s | %(name)s | %(message)s"))
+    logging.getLogger().addHandler(file_handler)
     result = DatasetPreparer(cfg).run()
     logging.info("Prepared dataset with %s pairs. Manifest: %s", result.total_pairs, result.manifest_path)
+    logging.info("Dataset directory for training: %s", Path(cfg.output_dir) / "mado")
     return 0
 
 

--- a/src/microseg/data_preparation/config.py
+++ b/src/microseg/data_preparation/config.py
@@ -48,6 +48,11 @@ class DatasetPrepConfig:
     mask_extensions: list[str] = field(default_factory=lambda: [".png", ".tif", ".tiff", ".jpg", ".jpeg"])
     mask_name_patterns: list[str] = field(default_factory=lambda: ["{stem}.png", "{stem}_mask.png", "{stem}.tif", "{stem}.tiff"])
     binarization_mode: Literal["nonzero", "threshold", "value_equals", "otsu", "percentile"] = "nonzero"
+    rgb_mask_mode: bool = False
+    mask_r_min: int = 200
+    mask_g_max: int = 60
+    mask_b_max: int = 60
+    enforce_gb_thresholds: bool = True
     threshold: int = 127
     threshold_strict: bool = False
     foreground_values: list[int] = field(default_factory=lambda: [255])
@@ -55,7 +60,13 @@ class DatasetPrepConfig:
     invert_mask: bool = False
     morphology: MorphologyConfig = field(default_factory=MorphologyConfig)
     target_size: tuple[int, int] = (512, 512)
-    resize_policy: Literal["letterbox_pad", "center_crop", "stretch", "keep_aspect_no_pad"] = "letterbox_pad"
+    resize_policy: Literal["letterbox_pad", "center_crop", "stretch", "keep_aspect_no_pad", "short_side_to_target_crop"] = "letterbox_pad"
+    crop_mode_train: Literal["center", "random"] = "random"
+    crop_mode_eval: Literal["center", "random"] = "center"
+    progress_log_interval: int = 20
+    qa_report_name: str = "dataset_qa_report.json"
+    html_report_name: str = "dataset_qa_report.html"
+    debug_sample_count: int = 0
     image_pad_mode: Literal["constant", "edge", "reflect"] = "constant"
     image_pad_value: int = 0
     image_interpolation: Literal["linear", "area", "cubic"] = "area"
@@ -71,6 +82,15 @@ class DatasetPrepConfig:
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "DatasetPrepConfig":
         data = dict(raw)
+        if isinstance(data.get("target_size"), int):
+            size = int(data["target_size"])
+            data["target_size"] = (size, size)
+        elif isinstance(data.get("target_size"), list):
+            target = data["target_size"]
+            if len(target) == 1:
+                data["target_size"] = (int(target[0]), int(target[0]))
+            elif len(target) == 2:
+                data["target_size"] = (int(target[0]), int(target[1]))
         morphology = MorphologyConfig(**data.pop("morphology", {}))
         debug = DebugConfig(**data.pop("debug", {}))
         cfg = cls(**data)

--- a/src/microseg/data_preparation/pairing.py
+++ b/src/microseg/data_preparation/pairing.py
@@ -15,6 +15,17 @@ class ImageMaskPair:
     mask_path: Path
 
 
+@dataclass(frozen=True)
+class PairCollectionReport:
+    """Pairing diagnostics for dataset ingestion."""
+
+    total_images: int
+    total_masks: int
+    pair_count: int
+    missing_masks: list[str]
+    missing_images: list[str]
+
+
 class PairCollector:
     """Collect paired segmentation image/mask files from an input folder."""
 
@@ -25,9 +36,17 @@ class PairCollector:
         self.strict = strict
 
     def collect(self, input_dir: Path) -> list[ImageMaskPair]:
-        images = sorted([p for p in input_dir.iterdir() if p.is_file() and p.suffix.lower() in self.image_extensions and "_mask" not in p.stem])
+        pairs, _ = self.collect_with_report(input_dir)
+        return pairs
+
+    def collect_with_report(self, input_dir: Path) -> tuple[list[ImageMaskPair], PairCollectionReport]:
+        files = [p for p in input_dir.iterdir() if p.is_file()]
+        images = sorted([p for p in files if p.suffix.lower() in self.image_extensions and "_mask" not in p.stem])
+        all_masks = sorted([p for p in files if p.suffix.lower() in self.mask_extensions])
+        image_stems = {p.stem for p in images}
+        mask_stems = {p.stem for p in all_masks}
         pairs: list[ImageMaskPair] = []
-        missing: list[str] = []
+        missing_masks: list[str] = []
         for image in images:
             stem = image.stem
             found = None
@@ -39,12 +58,24 @@ class PairCollector:
                     found = candidate
                     break
             if found is None:
-                missing.append(stem)
+                missing_masks.append(stem)
                 continue
             pairs.append(ImageMaskPair(stem=stem, image_path=image, mask_path=found))
 
+        missing_images = sorted(mask_stems - image_stems)
+        report = PairCollectionReport(
+            total_images=len(images),
+            total_masks=len(all_masks),
+            pair_count=len(pairs),
+            missing_masks=sorted(missing_masks),
+            missing_images=missing_images,
+        )
+
         if not pairs:
             raise RuntimeError(f"no image/mask pairs found in {input_dir}")
-        if missing and self.strict:
-            raise ValueError(f"missing masks for stems: {missing[:10]}")
-        return sorted(pairs, key=lambda p: p.stem)
+        if self.strict and (missing_masks or missing_images):
+            raise ValueError(
+                "pairing mismatch detected: "
+                f"missing_masks={missing_masks[:10]} missing_images={missing_images[:10]}"
+            )
+        return sorted(pairs, key=lambda p: p.stem), report

--- a/src/microseg/data_preparation/pipeline.py
+++ b/src/microseg/data_preparation/pipeline.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import random
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -16,7 +18,7 @@ from src.microseg.data_preparation.config import DatasetPrepConfig
 from src.microseg.data_preparation.debug import DebugInspector
 from src.microseg.data_preparation.exporters import MadoExporter, OxfordExporter
 from src.microseg.data_preparation.manifest import ManifestWriter
-from src.microseg.data_preparation.pairing import PairCollector
+from src.microseg.data_preparation.pairing import PairCollectionReport, PairCollector
 from src.microseg.data_preparation.resizing import Resizer
 
 
@@ -47,9 +49,13 @@ class DatasetPreparer:
         self.exporters = {"oxford": OxfordExporter(), "mado": MadoExporter()}
 
     def run(self) -> DatasetPrepareResult:
+        run_start = time.perf_counter()
         input_dir = Path(self.cfg.input_dir)
         output_dir = Path(self.cfg.output_dir)
-        pairs = self.collector.collect(input_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        pairs, pairing_report = self.collector.collect_with_report(input_dir)
+        self._log_pairing_report(pairing_report)
         if self.cfg.debug.enabled:
             pairs = pairs[: self.cfg.debug.limit_pairs]
 
@@ -61,16 +67,28 @@ class DatasetPreparer:
         warnings_all: list[str] = []
         split_for_index = {idx: split for split, idxs in split_map.items() for idx in idxs}
         records: list[dict[str, Any]] = []
-
+        read_failures: list[str] = []
         debug_written = 0
+
+        stage_start = time.perf_counter()
         for idx, pair in enumerate(pairs):
             split = split_for_index[idx]
             image = cv2.imread(str(pair.image_path), cv2.IMREAD_COLOR)
             mask_raw = cv2.imread(str(pair.mask_path), cv2.IMREAD_UNCHANGED)
             if image is None or mask_raw is None:
-                raise ValueError(f"failed to read pair: {pair}")
+                message = f"failed to read pair: {pair.stem}"
+                read_failures.append(message)
+                if self.cfg.strict_pairing:
+                    raise ValueError(message)
+                self.log.warning(message)
+                continue
             mask_binary, mask_stats = self.binarizer.apply(mask_raw)
-            image_out, mask_out, resize_warnings = self.resizer.apply(image, mask_binary)
+            image_out, mask_out, resize_warnings = self.resizer.apply(
+                image,
+                mask_binary,
+                split=split,
+                sample_seed=self.cfg.seed + idx,
+            )
             mask_warnings = [str(w) for w in mask_stats.get("warnings", [])]
             pair_warnings = [f"{pair.stem}: {w}" for w in [*mask_warnings, *resize_warnings]]
             for warning in pair_warnings:
@@ -114,19 +132,13 @@ class DatasetPreparer:
                     annotation=annotation,
                 )
                 debug_written += 1
+            self._log_progress(idx + 1, len(pairs), stage_start)
+
+        if read_failures:
+            warnings_all.extend(read_failures)
 
         manifest_records = self._serialize_records(records, output_dir)
-
-        if not self.cfg.debug.enabled or not self.cfg.debug.minimal_exports:
-            for style in self.cfg.styles:
-                exporter = self.exporters[style]
-                export_root = output_dir / style
-                exporter.export(export_root, records, dry_run=self.cfg.dry_run)
-        else:
-            for style in self.cfg.styles:
-                exporter = self.exporters[style]
-                export_root = output_dir / style
-                exporter.export(export_root, records[: min(10, len(records))], dry_run=self.cfg.dry_run)
+        self._export_styles(records, output_dir)
 
         manifest_path = self.manifest_writer.write(
             output_root=output_dir,
@@ -136,7 +148,74 @@ class DatasetPreparer:
             split_counts=split_counts,
             warnings=warnings_all,
         )
-        return DatasetPrepareResult(manifest_path=manifest_path, split_counts=split_counts, total_pairs=len(pairs))
+        self._write_qa_reports(
+            output_dir=output_dir,
+            records=records,
+            split_counts=split_counts,
+            pairing_report=pairing_report,
+            read_failures=read_failures,
+            elapsed_seconds=time.perf_counter() - run_start,
+        )
+        return DatasetPrepareResult(manifest_path=manifest_path, split_counts=split_counts, total_pairs=len(records))
+
+    def _export_styles(self, records: list[dict[str, Any]], output_dir: Path) -> None:
+        if not self.cfg.debug.enabled or not self.cfg.debug.minimal_exports:
+            rows = records
+        else:
+            rows = records[: min(10, len(records))]
+        for style in self.cfg.styles:
+            exporter = self.exporters[style]
+            export_root = output_dir / style
+            exporter.export(export_root, rows, dry_run=self.cfg.dry_run)
+
+    def _write_qa_reports(
+        self,
+        *,
+        output_dir: Path,
+        records: list[dict[str, Any]],
+        split_counts: dict[str, int],
+        pairing_report: PairCollectionReport,
+        read_failures: list[str],
+        elapsed_seconds: float,
+    ) -> None:
+        fg_ratios = [float(rec["mask_stats"].get("fg_ratio", 0.0)) for rec in records]
+        binary_sets = [tuple(rec["mask_stats"].get("unique_binary_values", [])) for rec in records]
+        qa = {
+            "schema_version": "microseg.dataset_prep_qa.v1",
+            "pairing": {
+                "total_images": pairing_report.total_images,
+                "total_masks": pairing_report.total_masks,
+                "pair_count": pairing_report.pair_count,
+                "missing_masks": pairing_report.missing_masks,
+                "missing_images": pairing_report.missing_images,
+            },
+            "split_counts": split_counts,
+            "processed_pairs": len(records),
+            "read_failures": read_failures,
+            "mask": {
+                "foreground_ratio_mean": float(np.mean(fg_ratios)) if fg_ratios else 0.0,
+                "foreground_ratio_min": float(np.min(fg_ratios)) if fg_ratios else 0.0,
+                "foreground_ratio_max": float(np.max(fg_ratios)) if fg_ratios else 0.0,
+                "binary_value_sets": sorted({str(v) for v in binary_sets}),
+            },
+            "timing": {
+                "elapsed_seconds": elapsed_seconds,
+            },
+            "dry_run": bool(self.cfg.dry_run),
+        }
+        qa_path = output_dir / self.cfg.qa_report_name
+        qa_path.write_text(json.dumps(qa, indent=2, sort_keys=True), encoding="utf-8")
+        html_path = output_dir / self.cfg.html_report_name
+        html_path.write_text(
+            "<html><body><h1>Dataset Preparation QA</h1>"
+            f"<p>processed_pairs={len(records)}</p>"
+            f"<p>split_counts={split_counts}</p>"
+            f"<p>missing_masks={len(pairing_report.missing_masks)}</p>"
+            f"<p>missing_images={len(pairing_report.missing_images)}</p>"
+            f"<p>elapsed_seconds={elapsed_seconds:.2f}</p>"
+            "</body></html>",
+            encoding="utf-8",
+        )
 
     def _serialize_records(self, records: list[dict[str, Any]], output_dir: Path) -> list[dict[str, Any]]:
         serialized: list[dict[str, Any]] = []
@@ -182,3 +261,23 @@ class DatasetPreparer:
                 raise ValueError(f"unreadable pair: {pair}")
             if img.shape[:2] != msk.shape[:2]:
                 raise ValueError(f"shape mismatch for {pair.stem}: {img.shape} vs {msk.shape}")
+
+    def _log_pairing_report(self, report: PairCollectionReport) -> None:
+        self.log.info(
+            "pairing summary images=%d masks=%d paired=%d missing_masks=%d missing_images=%d",
+            report.total_images,
+            report.total_masks,
+            report.pair_count,
+            len(report.missing_masks),
+            len(report.missing_images),
+        )
+
+    def _log_progress(self, done: int, total: int, start: float) -> None:
+        interval = max(1, int(self.cfg.progress_log_interval))
+        if done % interval != 0 and done != total:
+            return
+        elapsed = time.perf_counter() - start
+        per_item = elapsed / done if done else 0.0
+        eta = per_item * max(0, total - done)
+        pct = (100.0 * done / total) if total else 100.0
+        self.log.info("progress %d/%d (%.1f%%) elapsed=%.1fs eta=%.1fs", done, total, pct, elapsed, eta)

--- a/src/microseg/data_preparation/resizing.py
+++ b/src/microseg/data_preparation/resizing.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import random
+
 import cv2
 import numpy as np
 
@@ -26,7 +28,14 @@ class Resizer:
     def __init__(self, cfg: DatasetPrepConfig) -> None:
         self.cfg = cfg
 
-    def apply(self, image: np.ndarray, mask: np.ndarray) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    def apply(
+        self,
+        image: np.ndarray,
+        mask: np.ndarray,
+        *,
+        split: str | None = None,
+        sample_seed: int | None = None,
+    ) -> tuple[np.ndarray, np.ndarray, list[str]]:
         warnings: list[str] = []
         h, w = image.shape[:2]
         target_h, target_w = self.cfg.target_size
@@ -56,6 +65,27 @@ class Resizer:
             scaled_msk = cv2.resize(mask, (scaled_w, scaled_h), interpolation=cv2.INTER_NEAREST)
             start_x = max(0, (scaled_w - target_w) // 2)
             start_y = max(0, (scaled_h - target_h) // 2)
+            return (
+                scaled_img[start_y:start_y + target_h, start_x:start_x + target_w],
+                (scaled_msk[start_y:start_y + target_h, start_x:start_x + target_w] > 0).astype(np.uint8),
+                warnings,
+            )
+
+        if policy == "short_side_to_target_crop":
+            scale = max(target_w / w, target_h / h)
+            scaled_w = max(1, int(round(w * scale)))
+            scaled_h = max(1, int(round(h * scale)))
+            scaled_img = cv2.resize(image, (scaled_w, scaled_h), interpolation=_INTERP_MAP[self.cfg.image_interpolation])
+            scaled_msk = cv2.resize(mask, (scaled_w, scaled_h), interpolation=cv2.INTER_NEAREST)
+            crop_mode = self._resolve_crop_mode(split)
+            start_x, start_y = self._resolve_crop_origin(
+                scaled_w=scaled_w,
+                scaled_h=scaled_h,
+                target_w=target_w,
+                target_h=target_h,
+                crop_mode=crop_mode,
+                sample_seed=sample_seed,
+            )
             return (
                 scaled_img[start_y:start_y + target_h, start_x:start_x + target_w],
                 (scaled_msk[start_y:start_y + target_h, start_x:start_x + target_w] > 0).astype(np.uint8),
@@ -95,3 +125,29 @@ class Resizer:
             return out_img, out_msk.astype(np.uint8), warnings
 
         raise ValueError(f"unsupported resize policy: {policy}")
+
+    def _resolve_crop_mode(self, split: str | None) -> str:
+        if split == "train":
+            return self.cfg.crop_mode_train
+        if split in {"val", "test"}:
+            return self.cfg.crop_mode_eval
+        return self.cfg.crop_mode_eval
+
+    @staticmethod
+    def _resolve_crop_origin(
+        *,
+        scaled_w: int,
+        scaled_h: int,
+        target_w: int,
+        target_h: int,
+        crop_mode: str,
+        sample_seed: int | None,
+    ) -> tuple[int, int]:
+        max_x = max(0, scaled_w - target_w)
+        max_y = max(0, scaled_h - target_h)
+        if crop_mode == "center" or (max_x == 0 and max_y == 0):
+            return max_x // 2, max_y // 2
+        if crop_mode == "random":
+            rng = random.Random(sample_seed)
+            return rng.randint(0, max_x), rng.randint(0, max_y)
+        raise ValueError(f"unsupported crop mode: {crop_mode}")

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,5 +33,6 @@ Current phase coverage includes:
 - `test_phase21_benchmark_dashboard_enrichment.py` benchmark dashboard enrichment with training curves, training-history metrics, and aggregate comparison fields
 - `test_phase22_pretrained_offline.py` offline local pretrained registry validation, checksum verification, and local-bundle initialization smoke tests for `unet_binary`, `smp_unet_resnet18`, `hf_segformer_b0`, `transunet_tiny`, and `segformer_mini`
 
+- `test_data_preparation_module.py` paired image/mask collector, RGB red-threshold mask binarization, short-side resize+crop alignment, manifests, QA reports, and dry-run behavior
 - `test_mask_binary_normalization.py` binary-mask auto-normalization option (`two_value_zero_background`) for 2-value indexed masks
 - `test_service.py` legacy Flask service request validation for model selection, parameter parsing, and response behavior

--- a/tests/test_data_preparation_module.py
+++ b/tests/test_data_preparation_module.py
@@ -180,3 +180,97 @@ def test_cli_dry_run_writes_manifest_only(tmp_path: Path) -> None:
     assert code == 0
     assert (output_dir / "manifest.json").exists()
     assert not (output_dir / "oxford" / "images").exists()
+
+
+def test_mask_binarizer_rgb_threshold_mode() -> None:
+    raw = np.zeros((4, 4, 3), dtype=np.uint8)
+    raw[:, :, 2] = np.array([
+        [255, 220, 199, 100],
+        [210, 205, 180, 0],
+        [255, 255, 255, 255],
+        [200, 201, 202, 203],
+    ], dtype=np.uint8)
+    raw[:, :, 1] = np.array([
+        [0, 40, 30, 0],
+        [61, 55, 10, 0],
+        [0, 30, 60, 10],
+        [0, 10, 20, 100],
+    ], dtype=np.uint8)
+    cfg = DatasetPrepConfig(
+        input_dir="in",
+        output_dir="out",
+        rgb_mask_mode=True,
+        mask_r_min=200,
+        mask_g_max=60,
+        mask_b_max=60,
+    )
+    out, stats = MaskBinarizer(cfg).apply(raw)
+    assert set(np.unique(out).tolist()) == {0, 1}
+    assert stats["mode"] == "rgb_threshold"
+    assert int(out[0, 0]) == 1
+    assert int(out[0, 2]) == 0
+    assert int(out[1, 0]) == 0
+
+
+def test_resize_policy_short_side_to_target_crop_alignment() -> None:
+    img = np.zeros((20, 40, 3), dtype=np.uint8)
+    mask = np.zeros((20, 40), dtype=np.uint8)
+    img[:, 20:24, :] = 255
+    mask[:, 20:24] = 1
+
+    cfg = DatasetPrepConfig(
+        input_dir="in",
+        output_dir="out",
+        resize_policy="short_side_to_target_crop",
+        target_size=(16, 16),
+        crop_mode_train="random",
+        crop_mode_eval="center",
+        seed=13,
+    )  # type: ignore[arg-type]
+
+    out_img, out_mask, _ = Resizer(cfg).apply(img, mask, split="train", sample_seed=777)
+    assert out_img.shape[:2] == (16, 16)
+    assert out_mask.shape == (16, 16)
+    assert set(np.unique(out_mask).tolist()).issubset({0, 1})
+    bright = out_img[:, :, 0] > 0
+    assert np.array_equal(bright, out_mask > 0)
+
+
+def test_pipeline_paired_jpg_rgb_png_outputs_mado(tmp_path: Path) -> None:
+    input_dir = tmp_path / "pairs_rgb"
+    input_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(6):
+        image = np.full((48, 64, 3), 110 + i, dtype=np.uint8)
+        mask_rgb = np.zeros((48, 64, 3), dtype=np.uint8)
+        mask_rgb[:, 20:30, 0] = 0
+        mask_rgb[:, 20:30, 1] = 20
+        mask_rgb[:, 20:30, 2] = 230
+        Image.fromarray(image).save(input_dir / f"pair_{i}.jpg")
+        Image.fromarray(mask_rgb).save(input_dir / f"pair_{i}.png")
+
+    output_dir = tmp_path / "out_rgb"
+    cfg = DatasetPrepConfig.from_dict({
+        "input_dir": str(input_dir),
+        "output_dir": str(output_dir),
+        "styles": ["mado"],
+        "image_extensions": [".jpg", ".jpeg"],
+        "mask_extensions": [".png"],
+        "mask_name_patterns": ["{stem}.png"],
+        "rgb_mask_mode": True,
+        "resize_policy": "short_side_to_target_crop",
+        "target_size": 32,
+        "crop_mode_train": "random",
+        "crop_mode_eval": "center",
+    })
+    result = DatasetPreparer(cfg).run()
+    assert result.total_pairs == 6
+
+    for split in ["train", "val", "test"]:
+        for path in (output_dir / "mado" / split / "masks").glob("*.png"):
+            arr = np.asarray(Image.open(path).convert("L"), dtype=np.uint8)
+            assert arr.shape == (32, 32)
+            assert set(np.unique(arr).tolist()).issubset({0, 255})
+
+    qa = json.loads((output_dir / "dataset_qa_report.json").read_text(encoding="utf-8"))
+    assert qa["pairing"]["pair_count"] == 6
+    assert qa["split_counts"]["train"] + qa["split_counts"]["val"] + qa["split_counts"]["test"] == 6


### PR DESCRIPTION
### Motivation
- Provide a reproducible, well-logged dataset preparation path for paired `{stem}.jpg` inputs with RGB `{stem}.png` masks where hydrides are encoded as red-ish pixels, producing MaDo-style training layouts.
- Ensure masks are robustly converted to strict binary labels, add a deterministic short-side-to-target resize+crop policy suitable for training/validation/test, and emit machine-readable manifests and QA artifacts for traceability.

### Description
- Add config options and defaults to `DatasetPrepConfig` to enable `rgb_mask_mode`, `mask_r_min/mask_g_max/mask_b_max`, split-aware `crop_mode_train`/`crop_mode_eval`, `short_side_to_target_crop` resize policy, and QA/report naming keys (files modified: `src/microseg/data_preparation/config.py`, `configs/data_prep.default.yml`).
- Implement robust RGB red-threshold binarization with optional G/B suppression, grayscale fallback warning, per-channel stats and morphology cleanup integrated into the existing binarizer (file modified: `src/microseg/data_preparation/binarization.py`).
- Implement new `short_side_to_target_crop` resize policy that scales to make the smallest side equal target and then crops the target×target region with deterministic random or center crop choices (nearest-neighbor used for masks); crop origin is seeded per-sample for reproducibility (file modified: `src/microseg/data_preparation/resizing.py`).
- Enhance pairing to return a `PairCollectionReport` (missing masks/images counts) and surface pairing diagnostics to logs and QA (file modified: `src/microseg/data_preparation/pairing.py`).
- Extend pipeline to emit progress + ETA logging, record read-failures, write `manifest.json`, write `dataset_qa_report.json` and a lightweight HTML summary, and export MaDo/Oxford layouts as before; added deterministic seeding for per-sample crops and deterministic split assignment (file modified: `src/microseg/data_preparation/pipeline.py`, `src/microseg/data_preparation/exporters.py` unchanged except integration).
- Add CLI flags and file logging for the new flow in the module CLI and unified `scripts/microseg_cli.py` subcommand `prepare_dataset`, plus a hydride YAML preset to run the paired JPG+RGB->MaDo recipe (files added/updated: `src/microseg/data_preparation/cli.py`, `scripts/microseg_cli.py`, `configs/hydride/prepare_dataset.paired_rgb_mask.mado.yml`).
- Update docs and README to describe the new workflow and add unit/integration tests covering RGB mask binarization, resize+crop alignment, and the end-to-end paired JPG+PNG MaDo export (files updated: `docs/data_preparation.md`, `README.md`, `tests/test_data_preparation_module.py`, `tests/README.md`).

### Testing
- Ran byte-compilation of changed modules with `python -m compileall src/microseg/data_preparation scripts/microseg_cli.py tests/test_data_preparation_module.py`, which succeeded.
- Executed `pytest -q tests/test_data_preparation_module.py` in this environment but test collection failed due to OpenCV import error (`libGL.so.1` missing) in the runtime environment, so full automated test verification could not complete here.
- Attempted `python scripts/microseg_cli.py prepare_dataset --help` but it also failed in this environment for the same OpenCV lib dependency, while CLI code and usage examples were added and exercised in local compile and code-level validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1870418648324bc29f00d7f48ca5f)