### PR TITLE
Unify architecture-aware trained-model inference loading for GUI and adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ Inference:
 microseg-cli infer --config configs/inference.default.yml --set params.area_threshold=120
 ```
 
+
+## Unified trained-model inference loading
+
+Model-based inference now uses one architecture-aware loader shared by GUI, legacy API/service adapters, and ML inference entry points.
+
+- Discovery sources:
+  - training runs under `outputs/runs/<run_name>/`
+  - frozen registry entries in `frozen_checkpoints/model_registry.json`
+- Run eligibility requires successful metadata + checkpoint artifacts (`report.json` status ok/success/completed and resolvable `model_path`).
+- Failed/incomplete runs (for example folders with only `error_report.json`) are excluded from inference-capable discovery with explicit diagnostics.
+- Architecture is reconstructed from run metadata (`model_architecture` in report/manifest/config), then loaded via the unified binary-backend loader used in training/evaluation (`unet_binary`, SMP families, HF SegFormer/UPerNet, `transunet_tiny`, `segformer_mini`).
+
+For legacy service/API callers, pass one of:
+- `run_dir`
+- `registry_model_id`
+- `checkpoint_path`
+
+to select the exact inference artifact and avoid architecture mismatches.
+
+
 Training (UNet):
 ```bash
 microseg-cli train --config configs/train.default.yml --set epochs=20

--- a/docs/gui_user_guide.md
+++ b/docs/gui_user_guide.md
@@ -202,3 +202,27 @@ Smoke-stage models are debug-only and are not intended for scientific reporting.
   - top-bar `Load Sample`
 - Desktop logs are written to:
   - `outputs/logs/desktop/`
+
+
+## Trained model discovery (architecture-aware)
+
+The model dropdown now includes inference-capable trained models discovered from:
+
+- `outputs/runs/<run_name>/` (successful runs only)
+- frozen checkpoint registry entries when paths are valid
+
+A trained run is considered inference-eligible when it has:
+
+- `report.json` with status `ok`/`success`/`completed`
+- a resolvable model checkpoint path
+- architecture metadata (`model_architecture`) compatible with repo-supported trainable families
+
+Failed/incomplete runs are skipped and not shown as runnable model options.
+
+When troubleshooting model loading:
+
+1. confirm run status in `report.json`
+2. confirm checkpoint file exists at declared `model_path`
+3. confirm architecture is one of the supported trainable families
+4. verify required backend dependencies are installed (for example `transformers` for HF backends)
+

--- a/hydride_segmentation/inference.py
+++ b/hydride_segmentation/inference.py
@@ -1,100 +1,85 @@
-import os
 import logging
+import os
+from pathlib import Path
 from typing import Tuple
 
 import numpy as np
-from PIL import Image
-import torch
-import segmentation_models_pytorch as smp
 
 from src.microseg.core import resolve_torch_device
+from src.microseg.inference.trained_model_loader import (
+    InferenceModelReference,
+    load_reference_from_registry,
+    load_reference_from_run_dir,
+    run_reference_inference,
+)
 
-# Default directory for model weights
 DEFAULT_MODEL_DIR = os.getenv("HYDRIDE_MODEL_PATH", "/opt/models/hydride_segmentation/")
 DEFAULT_WEIGHTS = os.path.join(DEFAULT_MODEL_DIR, "model.pt")
 DEFAULT_ENABLE_GPU = os.getenv("MICROSEG_ENABLE_GPU", "0").strip().lower() in {"1", "true", "yes", "on"}
 DEFAULT_DEVICE_POLICY = os.getenv("MICROSEG_DEVICE_POLICY", "cpu")
 
 _logger = logging.getLogger(__name__)
-_model_cache: dict[tuple[str, str], torch.nn.Module] = {}
 
 
-def _normalize_device(device: str | None) -> str:
-    if not device:
-        return "cpu"
-    return str(device).strip().lower()
-
-
-def _resolve_device(params: dict | None = None) -> str:
+def _resolve_device(params: dict | None = None) -> tuple[bool, str]:
     cfg = params or {}
-    explicit = cfg.get("device")
-    if explicit:
-        return _normalize_device(str(explicit))
     enable_gpu = bool(cfg.get("enable_gpu", DEFAULT_ENABLE_GPU))
     policy = str(cfg.get("device_policy", DEFAULT_DEVICE_POLICY))
     resolved = resolve_torch_device(enable_gpu=enable_gpu, policy=policy)
     if resolved.fallback_used:
         _logger.info(resolved.reason)
-    return resolved.selected_device
+    return enable_gpu, policy
 
 
-def _load_model(weights_path: str = DEFAULT_WEIGHTS, *, device: str = "cpu") -> torch.nn.Module:
-    """Load segmentation model on the resolved device."""
-    model = smp.Unet(encoder_name="resnet18", encoder_weights=None,
-                     in_channels=3, classes=1)
-    state = torch.load(weights_path, map_location="cpu")
-    model.load_state_dict(state)
-    model.to(device)
-    model.eval()
-    return model
+def _reference_from_params(params: dict | None = None, weights_path: str = "") -> InferenceModelReference:
+    cfg = dict(params or {})
+    if str(cfg.get("run_dir", "")).strip():
+        return load_reference_from_run_dir(str(cfg["run_dir"]).strip())
+    if str(cfg.get("registry_model_id", "")).strip():
+        return load_reference_from_registry(str(cfg["registry_model_id"]).strip())
+    if str(cfg.get("checkpoint_path", "")).strip() or str(weights_path).strip():
+        ckpt = str(cfg.get("checkpoint_path") or weights_path).strip()
+        if not ckpt:
+            raise ValueError("checkpoint path resolved empty")
+        return InferenceModelReference(
+            reference_id=f"checkpoint::{Path(ckpt).name}",
+            display_name=f"Checkpoint: {Path(ckpt).name}",
+            source="checkpoint_path",
+            checkpoint_path=ckpt,
+            architecture=str(cfg.get("model_architecture", "")).strip().lower() or "unknown",
+            backend_label=str(cfg.get("backend", "")).strip().lower() or "custom",
+        )
+    return InferenceModelReference(
+        reference_id="checkpoint::default",
+        display_name="Checkpoint: default",
+        source="checkpoint_path",
+        checkpoint_path=DEFAULT_WEIGHTS,
+        architecture="unknown",
+        backend_label="legacy_default",
+    )
 
-def get_model(weights_path: str = DEFAULT_WEIGHTS, *, device: str = "cpu") -> torch.nn.Module:
-    """Return cached model instance for ``weights_path`` + ``device`` pair."""
 
-    dev = _normalize_device(device)
-    key = (os.path.abspath(weights_path), dev)
-    if key not in _model_cache:
-        try:
-            _model_cache[key] = _load_model(weights_path, device=dev)
-        except Exception:
-            if dev != "cpu":
-                _logger.exception("Failed to initialize model on '%s', retrying on CPU.", dev)
-                cpu_key = (os.path.abspath(weights_path), "cpu")
-                if cpu_key not in _model_cache:
-                    _model_cache[cpu_key] = _load_model(weights_path, device="cpu")
-                return _model_cache[cpu_key]
-            raise
-    return _model_cache[key]
+def run_model(
+    image_path: str,
+    params: dict | None = None,
+    weights_path: str = DEFAULT_WEIGHTS,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Run architecture-aware segmentation on an image."""
 
-def run_model(image_path: str, params: dict | None = None,
-              weights_path: str = DEFAULT_WEIGHTS) -> Tuple[np.ndarray, np.ndarray]:
-    """Run hydride segmentation on an image.
-
-    Parameters
-    ----------
-    image_path:
-        Path to the input image.
-    params:
-        Unused placeholder for compatibility with the GUI.
-    weights_path:
-        Optional path to model weights. Defaults to ``HYDRIDE_MODEL_PATH``.
-
-    Returns
-    -------
-    tuple
-        Tuple of ``(image, mask)`` numpy arrays where ``mask`` is ``uint8``.
-    """
     runtime_params = params or {}
-    device = _resolve_device(runtime_params)
-    model = get_model(weights_path, device=device)
-    model_device = next(model.parameters()).device.type
-    rgb = Image.open(image_path).convert("RGB")
-    arr = np.asarray(rgb, dtype=np.float32) / 255.0
-    tensor = torch.from_numpy(arr.transpose(2, 0, 1)).unsqueeze(0).to(model_device)
-
-    with torch.no_grad():
-        out = model(tensor)[0, 0]
-        mask = torch.sigmoid(out).cpu().numpy()
-
-    mask_bin = (mask > 0.5).astype(np.uint8) * 255
-    return np.array(rgb), mask_bin
+    enable_gpu, policy = _resolve_device(runtime_params)
+    reference = _reference_from_params(runtime_params, weights_path)
+    image, mask, manifest = run_reference_inference(
+        image_path,
+        reference,
+        enable_gpu=enable_gpu,
+        device_policy=policy,
+    )
+    _logger.info(
+        "ML inference complete: source=%s reference=%s architecture=%s checkpoint=%s",
+        manifest.get("source"),
+        manifest.get("reference_id"),
+        manifest.get("architecture"),
+        manifest.get("checkpoint_path"),
+    )
+    return image, mask

--- a/hydride_segmentation/microseg_adapter.py
+++ b/hydride_segmentation/microseg_adapter.py
@@ -16,6 +16,7 @@ LEGACY_GUI_MODEL_TO_ID = {
 
 def get_gui_model_options() -> list[str]:
     """Return model display names for desktop GUI selectors."""
+
     specs = build_hydride_registry().specs()
     return [spec.display_name for spec in specs]
 
@@ -54,6 +55,7 @@ def get_gui_model_specs() -> list[dict[str, str]]:
 
 def resolve_gui_model_id(model_name: str) -> str:
     """Resolve a GUI model label (new or legacy) to a model identifier."""
+
     specs = build_hydride_registry().specs()
     display_map = {spec.display_name: spec.model_id for spec in specs}
     if model_name in display_map:
@@ -63,6 +65,7 @@ def resolve_gui_model_id(model_name: str) -> str:
 
 def is_conventional_model(model_name: str) -> bool:
     """Return whether selected model uses conventional parameters."""
+
     return resolve_gui_model_id(model_name) == "hydride_conventional"
 
 
@@ -73,7 +76,7 @@ def run_pipeline(
     params: dict | None = None,
     include_analysis: bool = True,
 ):
-    """Run segmentation through the phase-1 microseg orchestration layer."""
+    """Run segmentation through the microseg orchestration layer."""
 
     pipeline = SegmentationPipeline.with_hydride_defaults()
     request = SegmentationRequest(
@@ -92,7 +95,7 @@ def run_pipeline_from_gui(
     *,
     include_analysis: bool = False,
 ):
-    """Map existing GUI model names to microseg model identifiers."""
+    """Map GUI model names to model identifiers."""
 
     model_id = resolve_gui_model_id(model_name)
     return run_pipeline(

--- a/hydride_segmentation/ml_api.py
+++ b/hydride_segmentation/ml_api.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from typing import Optional
+
 import numpy as np
 from PIL import Image
 
-from .inference import get_model, DEFAULT_WEIGHTS
-from src.microseg.core import resolve_torch_device
+from .inference import run_model
 
 
 def run_inference_from_image(
@@ -15,17 +15,24 @@ def run_inference_from_image(
     *,
     enable_gpu: bool = False,
     device_policy: str = "cpu",
+    run_dir: str = "",
+    registry_model_id: str = "",
 ) -> np.ndarray:
     """Return segmentation mask for a given ``image`` array."""
-    import torch
 
-    resolved = resolve_torch_device(enable_gpu=enable_gpu, policy=device_policy)
-    model = get_model(weights_path or DEFAULT_WEIGHTS, device=resolved.selected_device)
-    model_device = next(model.parameters()).device.type
-    rgb = Image.fromarray(image).convert("RGB")
-    arr = np.asarray(rgb, dtype=np.float32) / 255.0
-    tensor = torch.from_numpy(arr.transpose(2, 0, 1)).unsqueeze(0).to(model_device)
-    with torch.no_grad():
-        out = model(tensor)[0, 0]
-        mask = torch.sigmoid(out).cpu().numpy()
-    return (mask > 0.5).astype(np.uint8) * 255
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".png") as tmp:
+        Image.fromarray(image).convert("RGB").save(tmp.name)
+        _, mask = run_model(
+            tmp.name,
+            params={
+                "enable_gpu": enable_gpu,
+                "device_policy": device_policy,
+                "run_dir": run_dir,
+                "registry_model_id": registry_model_id,
+                "checkpoint_path": weights_path or "",
+            },
+            weights_path=weights_path or "",
+        )
+    return mask

--- a/hydride_segmentation/service.py
+++ b/hydride_segmentation/service.py
@@ -78,6 +78,12 @@ def infer():
             ml_params["enable_gpu"] = request.form.get("enable_gpu", "false").lower() == "true"
         if "device_policy" in request.form:
             ml_params["device_policy"] = request.form.get("device_policy", "cpu")
+        if "run_dir" in request.form:
+            ml_params["run_dir"] = request.form.get("run_dir", "")
+        if "registry_model_id" in request.form:
+            ml_params["registry_model_id"] = request.form.get("registry_model_id", "")
+        if "checkpoint_path" in request.form:
+            ml_params["checkpoint_path"] = request.form.get("checkpoint_path", "")
 
     tmp_path = _save_upload(file)
     try:

--- a/src/microseg/inference/__init__.py
+++ b/src/microseg/inference/__init__.py
@@ -4,10 +4,26 @@ from .predictors import (
     HydrideConventionalPredictor,
     HydrideMLPredictor,
     build_hydride_registry,
+    discover_dynamic_ml_model_bindings,
+)
+from .trained_model_loader import (
+    InferenceModelReference,
+    discover_inference_references,
+    load_reference_from_registry,
+    load_reference_from_run_dir,
+    run_reference_inference,
+    supported_trainable_architectures,
 )
 
 __all__ = [
     "HydrideConventionalPredictor",
     "HydrideMLPredictor",
+    "InferenceModelReference",
     "build_hydride_registry",
+    "discover_dynamic_ml_model_bindings",
+    "discover_inference_references",
+    "load_reference_from_registry",
+    "load_reference_from_run_dir",
+    "run_reference_inference",
+    "supported_trainable_architectures",
 ]

--- a/src/microseg/inference/predictors.py
+++ b/src/microseg/inference/predictors.py
@@ -1,52 +1,35 @@
-"""Predictor adapters backed by current hydride implementation."""
+"""Predictor adapters backed by conventional and unified trained-model inference loaders."""
 
 from __future__ import annotations
 
 from copy import deepcopy
-import logging
-from pathlib import Path
+from dataclasses import dataclass
 
-from hydride_segmentation.segmentation_mask_creation import run_model as run_conv_model
 from hydride_segmentation.legacy_api import DEFAULT_CONVENTIONAL_PARAMS
+from hydride_segmentation.segmentation_mask_creation import run_model as run_conv_model
 
 from src.microseg.domain import ModelSpec, SegmentationOutput
-from src.microseg.plugins import find_repo_root, frozen_checkpoint_map
+from src.microseg.inference.trained_model_loader import (
+    InferenceModelReference,
+    discover_inference_references,
+    load_reference_from_registry,
+    load_reference_from_run_dir,
+    run_reference_inference,
+)
 from src.microseg.plugins import ModelRegistry
 
 
-_logger = logging.getLogger(__name__)
-
-
-def _resolve_registry_weights_path(model_id: str) -> str | None:
-    """Resolve model checkpoint path from frozen-checkpoint metadata if available."""
-
-    try:
-        records = frozen_checkpoint_map()
-    except Exception as exc:
-        _logger.debug("Could not load frozen checkpoint registry: %s", exc)
-        return None
-
-    rec = records.get(model_id)
-    if rec is None:
-        return None
-    hint = str(rec.checkpoint_path_hint).strip()
-    if not hint or hint.lower().startswith("n/a"):
-        return None
-
-    hinted_path = Path(hint)
-    if hinted_path.is_absolute():
-        return str(hinted_path) if hinted_path.exists() else None
-
-    try:
-        root = find_repo_root(Path(__file__))
-    except Exception:
-        root = Path.cwd()
-    resolved = (root / hinted_path).resolve()
-    return str(resolved) if resolved.exists() else None
+@dataclass(frozen=True)
+class _DynamicModelBinding:
+    model_id: str
+    display_name: str
+    description: str
+    details: str
+    reference: InferenceModelReference
 
 
 class HydrideConventionalPredictor:
-    """Adapter for the current conventional hydride segmentation path."""
+    """Adapter for conventional hydride segmentation path."""
 
     model_id = "hydride_conventional"
 
@@ -59,24 +42,80 @@ class HydrideConventionalPredictor:
 
 
 class HydrideMLPredictor:
-    """Adapter for the current ML hydride inference path."""
+    """Legacy ML adapter now routed through unified architecture-aware loader."""
 
     model_id = "hydride_ml"
 
     def predict(self, image_path: str, params: dict | None = None) -> SegmentationOutput:
-        # Lazy import keeps non-ML paths usable without ML-only dependencies.
-        from hydride_segmentation.inference import run_model as run_ml_model
+        cfg = dict(params or {})
+        run_dir = str(cfg.get("run_dir", "")).strip()
+        registry_model_id = str(cfg.get("registry_model_id", "")).strip()
+        checkpoint_path = str(cfg.get("checkpoint_path", cfg.get("weights_path", ""))).strip()
 
-        params = dict(params or {})
-        weights_path = str(params.get("weights_path", "")).strip()
-        if not weights_path:
-            reg_path = _resolve_registry_weights_path(self.model_id)
-            if reg_path:
-                params["weights_path"] = reg_path
-                weights_path = reg_path
-                _logger.info("Hydride ML resolved checkpoint from frozen registry: %s", reg_path)
-        image, mask = run_ml_model(image_path, params=params, weights_path=weights_path) if weights_path else run_ml_model(image_path, params=params)
+        if run_dir:
+            ref = load_reference_from_run_dir(run_dir)
+        elif registry_model_id:
+            ref = load_reference_from_registry(registry_model_id)
+        elif checkpoint_path:
+            ref = InferenceModelReference(
+                reference_id=f"checkpoint::{checkpoint_path}",
+                display_name="Direct checkpoint",
+                source="checkpoint_path",
+                checkpoint_path=checkpoint_path,
+                architecture=str(cfg.get("model_architecture", "")).strip().lower() or "unknown",
+                backend_label=str(cfg.get("backend", "")).strip().lower() or "custom",
+            )
+        else:
+            raise ValueError(
+                "hydride_ml requires one of: params.run_dir, params.registry_model_id, or params.checkpoint_path"
+            )
+
+        image, mask, _ = run_reference_inference(
+            image_path,
+            ref,
+            enable_gpu=bool(cfg.get("enable_gpu", False)),
+            device_policy=str(cfg.get("device_policy", "cpu")),
+        )
         return SegmentationOutput(image=image, mask=mask)
+
+
+class ReferencePredictor:
+    """Predictor bound to a resolved inference reference."""
+
+    def __init__(self, reference: InferenceModelReference) -> None:
+        self.reference = reference
+
+    def predict(self, image_path: str, params: dict | None = None) -> SegmentationOutput:
+        cfg = dict(params or {})
+        image, mask, _ = run_reference_inference(
+            image_path,
+            self.reference,
+            enable_gpu=bool(cfg.get("enable_gpu", False)),
+            device_policy=str(cfg.get("device_policy", "cpu")),
+        )
+        return SegmentationOutput(image=image, mask=mask)
+
+
+def discover_dynamic_ml_model_bindings() -> tuple[list[_DynamicModelBinding], list[str]]:
+    """Discover inference-ready run/registry models for GUI and pipeline registry."""
+
+    refs, warnings = discover_inference_references(include_registry=True)
+    bindings: list[_DynamicModelBinding] = []
+    for ref in refs:
+        model_id = f"hydride_trained::{ref.reference_id}"
+        bindings.append(
+            _DynamicModelBinding(
+                model_id=model_id,
+                display_name=ref.display_name,
+                description=f"Trained {ref.architecture} model ({ref.source})",
+                details=(
+                    f"Architecture={ref.architecture}, backend={ref.backend_label}, "
+                    f"checkpoint={ref.checkpoint_path}"
+                ),
+                reference=ref,
+            )
+        )
+    return bindings, warnings
 
 
 def build_hydride_registry(registry: ModelRegistry | None = None) -> ModelRegistry:
@@ -91,8 +130,7 @@ def build_hydride_registry(registry: ModelRegistry | None = None) -> ModelRegist
             description="CLAHE + adaptive threshold + morphology",
             details=(
                 "Classical CPU-first pipeline for hydride-like contrast patterns. "
-                "Includes CLAHE normalization, adaptive thresholding, and morphology. "
-                "Best for quick baseline runs and environments without ML weights."
+                "Includes CLAHE normalization, adaptive thresholding, and morphology."
             ),
         ),
         factory=HydrideConventionalPredictor,
@@ -100,15 +138,24 @@ def build_hydride_registry(registry: ModelRegistry | None = None) -> ModelRegist
     reg.register(
         ModelSpec(
             model_id="hydride_ml",
-            display_name="Hydride ML",
+            display_name="Hydride ML (legacy adapter)",
             feature_family="hydride",
-            description="UNet-based hydride segmentation model",
-            details=(
-                "UNet-like learned predictor for hydride segmentation. "
-                "Requires model weights and is generally more flexible for "
-                "heterogeneous image contrast; validate with correction workflow."
-            ),
+            description="Legacy adapter redirected to unified trained-model loader",
+            details="Use run_dir/registry_model_id/checkpoint_path params for architecture-aware loading.",
         ),
         factory=HydrideMLPredictor,
     )
+
+    bindings, _warnings = discover_dynamic_ml_model_bindings()
+    for binding in bindings:
+        reg.register(
+            ModelSpec(
+                model_id=binding.model_id,
+                display_name=binding.display_name,
+                feature_family="hydride",
+                description=binding.description,
+                details=binding.details,
+            ),
+            factory=lambda ref=binding.reference: ReferencePredictor(ref),
+        )
     return reg

--- a/src/microseg/inference/trained_model_loader.py
+++ b/src/microseg/inference/trained_model_loader.py
@@ -1,0 +1,229 @@
+"""Unified architecture-aware loading for trainable segmentation backends."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+from src.microseg.plugins import find_repo_root, frozen_checkpoint_map
+from src.microseg.training.unet_binary import load_unet_binary_model, predict_unet_binary_mask
+
+_SUPPORTED_ARCHITECTURES: tuple[str, ...] = (
+    "unet_binary",
+    "smp_unet_resnet18",
+    "smp_unetplusplus_resnet101",
+    "smp_deeplabv3plus_resnet101",
+    "smp_pspnet_resnet50",
+    "smp_fpn_resnet34",
+    "transunet_tiny",
+    "segformer_mini",
+    "hf_segformer_b0",
+    "hf_segformer_b2",
+    "hf_segformer_b5",
+    "hf_upernet_swin_large",
+)
+
+
+@dataclass(frozen=True)
+class InferenceModelReference:
+    """Resolved model metadata for an inference-capable trained artifact."""
+
+    reference_id: str
+    display_name: str
+    source: str
+    checkpoint_path: str
+    architecture: str
+    backend_label: str
+    run_dir: str = ""
+    manifest_path: str = ""
+
+
+def supported_trainable_architectures() -> tuple[str, ...]:
+    """Return architecture identifiers supported by training/inference loader."""
+
+    return _SUPPORTED_ARCHITECTURES
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists() or not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _architecture_from_payload(*payloads: dict[str, Any]) -> str:
+    for payload in payloads:
+        arch = str(payload.get("model_architecture", "")).strip().lower()
+        if arch:
+            return arch
+        cfg = payload.get("config")
+        if isinstance(cfg, dict):
+            nested = str(cfg.get("model_architecture", "")).strip().lower()
+            if nested:
+                return nested
+    return ""
+
+
+def _backend_from_payload(*payloads: dict[str, Any]) -> str:
+    for payload in payloads:
+        backend = str(payload.get("backend", "")).strip().lower()
+        if backend:
+            return backend
+        cfg = payload.get("config")
+        if isinstance(cfg, dict):
+            nested = str(cfg.get("backend_label", cfg.get("backend", ""))).strip().lower()
+            if nested:
+                return nested
+    return ""
+
+
+def load_reference_from_run_dir(run_dir: str | Path) -> InferenceModelReference:
+    """Resolve model reference from a training run directory."""
+
+    root = Path(run_dir).resolve()
+    if not root.exists() or not root.is_dir():
+        raise FileNotFoundError(f"run directory does not exist: {root}")
+
+    report = _read_json(root / "report.json")
+    if str(report.get("status", "")).strip().lower() not in {"ok", "success", "completed"}:
+        raise ValueError(f"run is not inference-eligible (status={report.get('status', 'unknown')!r}): {root}")
+
+    manifest = _read_json(root / "training_manifest.json")
+    resolved_cfg = _read_json(root / "resolved_config.json")
+
+    model_path = str(
+        report.get("model_path")
+        or manifest.get("model_path")
+        or resolved_cfg.get("model_path")
+        or ""
+    ).strip()
+    if not model_path:
+        raise ValueError(f"missing model_path in run metadata: {root}")
+
+    candidate = Path(model_path)
+    ckpt_path = (candidate if candidate.is_absolute() else (root / candidate)).resolve()
+    if not ckpt_path.exists():
+        raise FileNotFoundError(f"checkpoint declared by run metadata does not exist: {ckpt_path}")
+
+    architecture = _architecture_from_payload(report, manifest, resolved_cfg)
+    if not architecture:
+        raise ValueError(f"missing model_architecture metadata in {root}")
+    if architecture not in _SUPPORTED_ARCHITECTURES:
+        raise ValueError(f"unsupported architecture for inference: {architecture}")
+
+    backend = _backend_from_payload(report, manifest, resolved_cfg) or architecture
+    return InferenceModelReference(
+        reference_id=f"run::{root.name}",
+        display_name=f"Run: {root.name} ({architecture})",
+        source="run_dir",
+        checkpoint_path=str(ckpt_path),
+        architecture=architecture,
+        backend_label=backend,
+        run_dir=str(root),
+        manifest_path=str(root / "training_manifest.json") if (root / "training_manifest.json").exists() else "",
+    )
+
+
+def load_reference_from_registry(model_id: str) -> InferenceModelReference:
+    """Resolve model reference from frozen-checkpoint registry entry."""
+
+    records = frozen_checkpoint_map()
+    rec = records.get(model_id)
+    if rec is None:
+        raise KeyError(f"unknown frozen checkpoint model_id: {model_id}")
+
+    hint = str(rec.checkpoint_path_hint or "").strip()
+    if not hint:
+        raise ValueError(f"registry model has empty checkpoint_path_hint: {model_id}")
+
+    path = Path(hint)
+    if not path.is_absolute():
+        path = (find_repo_root(Path(__file__)) / path).resolve()
+    if not path.exists():
+        raise FileNotFoundError(f"registry checkpoint path does not exist: {path}")
+
+    architecture = str(rec.model_type or "").strip().lower()
+    if architecture not in _SUPPORTED_ARCHITECTURES:
+        raise ValueError(f"registry model has unsupported architecture {architecture!r}: {model_id}")
+
+    return InferenceModelReference(
+        reference_id=f"registry::{model_id}",
+        display_name=f"Registry: {rec.model_nickname} ({architecture})",
+        source="registry",
+        checkpoint_path=str(path),
+        architecture=architecture,
+        backend_label=architecture,
+    )
+
+
+def discover_inference_references(
+    *,
+    runs_root: str | Path | None = None,
+    include_registry: bool = True,
+) -> tuple[list[InferenceModelReference], list[str]]:
+    """Discover inference-capable models from run folders and optionally registry."""
+
+    refs: list[InferenceModelReference] = []
+    warnings: list[str] = []
+
+    if runs_root is None:
+        try:
+            runs_root = find_repo_root(Path(__file__)) / "outputs" / "runs"
+        except Exception:
+            runs_root = Path("outputs/runs")
+
+    root = Path(runs_root)
+    if root.exists() and root.is_dir():
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            try:
+                refs.append(load_reference_from_run_dir(child))
+            except Exception as exc:
+                warnings.append(f"skip run {child.name}: {exc}")
+
+    if include_registry:
+        try:
+            for model_id in sorted(frozen_checkpoint_map().keys()):
+                try:
+                    refs.append(load_reference_from_registry(model_id))
+                except Exception as exc:
+                    warnings.append(f"skip registry {model_id}: {exc}")
+        except Exception as exc:
+            warnings.append(f"failed to read frozen registry: {exc}")
+
+    return refs, warnings
+
+
+def run_reference_inference(
+    image_path: str | Path,
+    reference: InferenceModelReference,
+    *,
+    enable_gpu: bool = False,
+    device_policy: str = "cpu",
+) -> tuple[np.ndarray, np.ndarray, dict[str, Any]]:
+    """Run segmentation with a resolved model reference."""
+
+    image = np.asarray(Image.open(image_path).convert("RGB"), dtype=np.uint8)
+    bundle = load_unet_binary_model(
+        reference.checkpoint_path,
+        enable_gpu=enable_gpu,
+        device_policy=device_policy,
+    )
+    pred = predict_unet_binary_mask(image, bundle).astype(np.uint8) * 255
+    return image, pred, {
+        "reference_id": reference.reference_id,
+        "architecture": reference.architecture,
+        "backend": reference.backend_label,
+        "source": reference.source,
+        "checkpoint_path": reference.checkpoint_path,
+        "device": bundle.get("device", "cpu"),
+    }

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,3 +43,5 @@ Current phase coverage includes:
 - `test_data_preparation_module.py` paired image/mask collector, RGB red-threshold + red-dominance fallback binarization, noisy-grayscale auto-Otsu fallback, short-side resize+crop alignment, empty-mask warn/error policy, manifests/QA reports, debug criteria exports, and dry-run behavior
 - `test_mask_binary_normalization.py` binary-mask auto-normalization option (`two_value_zero_background`) for 2-value indexed masks
 - `test_service.py` legacy Flask service request validation for model selection, parameter parsing, and response behavior
+
+- `test_phase30_unified_inference_loader.py` unified architecture-aware inference discovery/loading across run folders, failed-run rejection, and GUI model option integration

--- a/tests/test_phase14_checkpoint_lifecycle.py
+++ b/tests/test_phase14_checkpoint_lifecycle.py
@@ -3,51 +3,16 @@
 from __future__ import annotations
 
 from pathlib import Path
-import sys
-import types
-
-import numpy as np
-
 from src.microseg.inference.predictors import HydrideMLPredictor
 from src.microseg.plugins import FrozenCheckpointRecord
 from src.microseg.plugins.registry_validation import validate_frozen_registry
 
 
-def test_phase14_ml_predictor_uses_registry_hint_when_weights_missing(tmp_path: Path, monkeypatch) -> None:
-    hinted = tmp_path / "frozen_checkpoints" / "smoke" / "torch_pixel_smoke_random_v1.pth"
-    hinted.parent.mkdir(parents=True, exist_ok=True)
-    hinted.write_bytes(b"smoke")
+def test_phase14_ml_predictor_requires_explicit_unified_selector() -> None:
+    import pytest
 
-    record = FrozenCheckpointRecord(
-        model_id="hydride_ml",
-        model_nickname="smoke",
-        model_type="binary_unet",
-        framework="pytorch",
-        input_size="variable",
-        input_dimensions="H x W x 3",
-        checkpoint_path_hint="frozen_checkpoints/smoke/torch_pixel_smoke_random_v1.pth",
-        application_remarks="smoke",
-        classes=tuple(),
-    )
-
-    monkeypatch.setattr("src.microseg.inference.predictors.frozen_checkpoint_map", lambda: {"hydride_ml": record})
-    monkeypatch.setattr("src.microseg.inference.predictors.find_repo_root", lambda _start=None: tmp_path)
-
-    observed: dict[str, str] = {}
-    fake_module = types.ModuleType("hydride_segmentation.inference")
-
-    def _fake_run_model(image_path: str, params=None, weights_path: str = ""):  # noqa: ANN001
-        observed["image_path"] = image_path
-        observed["weights_path"] = weights_path
-        return np.zeros((8, 8, 3), dtype=np.uint8), np.zeros((8, 8), dtype=np.uint8)
-
-    fake_module.run_model = _fake_run_model  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "hydride_segmentation.inference", fake_module)
-
-    out = HydrideMLPredictor().predict("dummy_input.png", params={})
-    assert out.image.shape == (8, 8, 3)
-    assert out.mask.shape == (8, 8)
-    assert observed["weights_path"] == str(hinted.resolve())
+    with pytest.raises(ValueError, match="requires one of"):
+        HydrideMLPredictor().predict("dummy_input.png", params={})
 
 
 def test_phase14_registry_validation_accepts_lifecycle_optional_fields(tmp_path: Path) -> None:

--- a/tests/test_phase1_microseg_core.py
+++ b/tests/test_phase1_microseg_core.py
@@ -32,7 +32,8 @@ def _write_temp_image(image: np.ndarray) -> str:
 
 def test_hydride_registry_contains_phase1_models() -> None:
     reg = build_hydride_registry()
-    assert sorted(reg.model_ids()) == ["hydride_conventional", "hydride_ml"]
+    assert "hydride_conventional" in reg.model_ids()
+    assert "hydride_ml" in reg.model_ids()
 
 
 def test_microseg_pipeline_conventional_matches_legacy_mask() -> None:

--- a/tests/test_phase30_unified_inference_loader.py
+++ b/tests/test_phase30_unified_inference_loader.py
@@ -1,0 +1,102 @@
+"""Phase 30 tests for unified architecture-aware inference loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from hydride_segmentation.inference import run_model
+from hydride_segmentation.microseg_adapter import get_gui_model_options
+from src.microseg.inference import discover_inference_references
+from src.microseg.inference.trained_model_loader import load_reference_from_run_dir
+from src.microseg.training.unet_binary import _build_binary_model
+
+
+def _write_synthetic_run(root: Path, *, name: str, status: str = "ok") -> Path:
+    import torch
+
+    run_dir = root / name
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    model = _build_binary_model(
+        architecture="unet_binary",
+        base_channels=8,
+        transformer_depth=2,
+        transformer_num_heads=4,
+        transformer_mlp_ratio=2.0,
+        transformer_dropout=0.0,
+        segformer_patch_size=4,
+    )
+    ckpt_path = run_dir / "best_model.pt"
+    torch.save(
+        {
+            "schema_version": "microseg.torch_unet_binary.v1",
+            "model_state_dict": model.state_dict(),
+            "model_architecture": "unet_binary",
+            "backend": "unet_binary_local_pretrained",
+            "config": {"model_architecture": "unet_binary", "model_base_channels": 8},
+        },
+        ckpt_path,
+    )
+
+    (run_dir / "report.json").write_text(
+        json.dumps({"status": status, "model_path": "best_model.pt", "model_architecture": "unet_binary"}, indent=2),
+        encoding="utf-8",
+    )
+    (run_dir / "training_manifest.json").write_text(
+        json.dumps({"model_path": "best_model.pt", "model_architecture": "unet_binary"}, indent=2),
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def test_phase30_discovery_rejects_failed_runs(tmp_path: Path) -> None:
+    runs = tmp_path / "outputs" / "runs"
+    _write_synthetic_run(runs, name="ok_run", status="ok")
+    _write_synthetic_run(runs, name="failed_run", status="failed")
+
+    refs, warnings = discover_inference_references(runs_root=runs, include_registry=False)
+    ids = [ref.reference_id for ref in refs]
+
+    assert "run::ok_run" in ids
+    assert "run::failed_run" not in ids
+    assert any("failed_run" in warn for warn in warnings)
+
+
+def test_phase30_inference_run_dir_loads_and_predicts(tmp_path: Path) -> None:
+    runs = tmp_path / "outputs" / "runs"
+    run_dir = _write_synthetic_run(runs, name="unet_binary_local_pretrained_seed42", status="ok")
+
+    image = np.zeros((64, 64, 3), dtype=np.uint8)
+    image[:, 32:] = 255
+    img_path = tmp_path / "sample.png"
+    Image.fromarray(image).save(img_path)
+
+    ref = load_reference_from_run_dir(run_dir)
+    assert ref.architecture == "unet_binary"
+
+    rgb, mask = run_model(
+        str(img_path),
+        params={"run_dir": str(run_dir), "enable_gpu": False, "device_policy": "cpu"},
+    )
+    assert rgb.shape == image.shape
+    assert mask.shape == image.shape[:2]
+
+
+def test_phase30_gui_options_include_discovered_trained_models(tmp_path: Path, monkeypatch) -> None:
+    runs = tmp_path / "outputs" / "runs"
+    _write_synthetic_run(runs, name="gui_run_model", status="ok")
+    monkeypatch.setenv("PYTHONHASHSEED", "0")
+
+    from src.microseg.inference import predictors as pred
+
+    def _fake_discover(*, include_registry=True):  # noqa: ARG001
+        return discover_inference_references(runs_root=runs, include_registry=False)
+
+    monkeypatch.setattr(pred, "discover_inference_references", _fake_discover)
+
+    options = get_gui_model_options()
+    assert any("gui_run_model" in name for name in options)


### PR DESCRIPTION
### Motivation
- The desktop GUI and legacy inference paths were tied to an older UNet-only flow and could not reliably load benchmark-trained run artifacts for the multiple model families the repo supports, causing architecture mismatches and poor UX. 
- Provide a single, manifest/registry-driven inference contract so GUI, CLI, service and programmatic entry points can discover and run any trainable architecture supported by the repo without fragile heuristics.

### Description
- Added a unified architecture-aware loader at `src/microseg/inference/trained_model_loader.py` that exposes `InferenceModelReference`, discovers inference-capable artifacts from `outputs/runs/*` and the frozen-checkpoint registry, validates `report.json`/`training_manifest.json`/`resolved_config.json`, and enumerates supported trainable families. 
- Refactored inference surfaces to use the new loader and a consistent selector contract: `hydride_segmentation/inference.py`, `hydride_segmentation/ml_api.py`, `hydride_segmentation/service.py`, and `src/microseg/inference/predictors.py` now accept `run_dir`, `registry_model_id`, or `checkpoint_path` and route execution through the shared loader (`run_reference_inference`).
- Integrated dynamic model bindings into the registry so the GUI model dropdown lists only inference-capable trained runs (new `ReferencePredictor` + discovered `hydride_trained::...` bindings) while preserving the `hydride_conventional` workflow and keeping `hydride_ml` as a compatibility adapter that now requires an explicit artifact selector. 
- Updated docs and tests: added `tests/test_phase30_unified_inference_loader.py`, updated `tests/test_phase1_microseg_core.py` and `tests/test_phase14_checkpoint_lifecycle.py`, and documented discovery/selection behavior in `README.md`, `docs/gui_user_guide.md`, and `tests/README.md`.

### Testing
- Initial collection failed when running `pytest -q ...` without module path due to import resolution, so tests were run with repository root on `PYTHONPATH` using `PYTHONPATH=. pytest -q tests/test_phase30_unified_inference_loader.py tests/test_phase1_microseg_core.py tests/test_phase14_checkpoint_lifecycle.py tests/test_service.py`, which completed successfully with all tests passing (`13 passed, 4 warnings`).
- The new test `tests/test_phase30_unified_inference_loader.py` validates discovery (skips failed runs), run-dir checkpoint resolution and inference, and GUI dropdown integration, and it passed in the CI-local run. 
- Only non-fatal warnings were observed (skimage deprecation notices), and runtime behavior preserves backward compatibility for the conventional path while enforcing explicit artifact selection for ML to avoid architecture mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3ddc8f2cc8324adfc8d04e23f9faa)