### PR TITLE
Folder-recursive inference, batch preview exports, artifacts manifest, and GUI batch inspector

### DIFF
--- a/docs/gui_user_guide.md
+++ b/docs/gui_user_guide.md
@@ -81,6 +81,29 @@ Report customization controls:
 Batch export:
 - `Export Batch Summary` (menu/button) exports selected history runs or all runs if none selected.
 - outputs: `batch_results_summary.json`, `batch_results_report.html`, optional `batch_results_report.pdf`, `batch_metrics.csv`
+- batch summary now also includes `artifacts_manifest.json` and `preview_images/` for row-by-row visual inspection.
+
+## Recursive Folder Inference (GUI + CLI parity)
+
+`Run Batch` supports folder-first operation:
+
+1. Click `Run Batch`.
+2. Select an input folder (or cancel to fall back to manual file selection).
+3. The app scans recursively (default) for configured image globs (`*.png`, `*.jpg`, `*.jpeg`, `*.tif`, `*.tiff`, `*.bmp`).
+4. Each discovered image is inferred and added to history with full per-run provenance.
+
+The exported batch HTML includes one aligned row per image with:
+
+- input image preview
+- predicted mask preview
+- overlay preview
+- key scalar metrics (including hydride area fraction/count when available)
+
+GUI-native batch summary inspector:
+
+- open from `File -> Open Batch Results Summary...` or `Results Dashboard -> Open Batch Summary`
+- load any exported `batch_results_summary.json`
+- inspect aggregate batch summary at top, select per-image rows on the left, and review large input/mask/overlay panels with detailed per-image statistics on the right
 
 ## Session Persistence
 

--- a/docs/hpc_ga_user_guide.md
+++ b/docs/hpc_ga_user_guide.md
@@ -59,6 +59,13 @@ Feedback analysis in GUI:
 
 ## Quick Start (CLI)
 
+Environment/bootstrap (recommended before running GA commands):
+
+```bash
+python -m pip install -e .
+microseg-cli models --details
+```
+
 ```bash
 microseg-cli hpc-ga-generate \
   --config configs/hpc_ga.default.yml \
@@ -96,6 +103,15 @@ microseg-cli hpc-ga-feedback-report \
   --config configs/hpc_ga.default.yml \
   --feedback-sources outputs/hpc_ga_bundle_a,outputs/hpc_ga_bundle_b \
   --output-path outputs/hpc_ga_feedback/feedback_report.json
+```
+
+If CLI import errors occur (`No module named src`), run from repo root using module form:
+
+```bash
+python -m scripts.microseg_cli hpc-ga-generate \
+  --config configs/hpc_ga.default.yml \
+  --dataset-dir outputs/prepared_dataset \
+  --output-dir outputs/hpc_ga_bundle
 ```
 
 ## Upload And Run On HPC

--- a/docs/mission_statement.md
+++ b/docs/mission_statement.md
@@ -25,6 +25,7 @@ Deliver a field-ready local desktop product and backend toolkit that can:
 - Frozen-checkpoint metadata registry for model selection and guidance
 - Checkpoint lifecycle management (`smoke`, `candidate`, `promoted`) with git-tracked metadata and git-ignored binaries
 - Human-readable + machine-readable run reporting (`json` + `html`)
+- Human-centered batch-inspection workflow as a first-class requirement: every folder-scale inference path (GUI + CLI) must provide intuitive visual review with per-image previews, per-image metrics, and aggregate statistics in machine-ingestible + human-readable outputs
 - Deployment-grade result reporting (`json` + `html` + `pdf`) for audit and handoff
 - Offline installer workflows for enterprise desktop deployment (single-file setup artifacts)
 - Mandatory end-of-phase quality gates (tests + stocktake + gap review + docs sync)
@@ -59,6 +60,7 @@ Deliver a field-ready local desktop product and backend toolkit that can:
 17. Provide feedback-aware candidate ranking for later HPC sweeps using prior run metrics and reproducible reporting artifacts.
 18. Deliver enterprise-ready desktop UX with professional menus, bundled sample inputs, and persistent operational logging.
 19. Provide installer-grade packaging instructions/scripts for offline Windows deployment.
+20. Treat folder-scale inference review as a foundational workflow, with GUI-native inspection of exported batch summaries and per-image evidence alongside aggregate statistics.
 
 ## Success Criteria
 
@@ -72,6 +74,7 @@ Deliver a field-ready local desktop product and backend toolkit that can:
 - Saved project sessions can be reopened and resumed without data loss.
 - Hydride workflows remain stable while generalization is implemented.
 - Desktop users can export full run evidence packages (images + masks + metrics + HTML/PDF reports) without external tooling.
+- Desktop users can inspect recursive folder-inference summaries in-app, including row-aligned input/mask/overlay previews, per-image metrics, and aggregate batch statistics.
 - Desktop workflows support optional spatial calibration so size statistics can be reported in physical units when scale is available.
 - Documentation is treated as a first-class deliverable: commands, outputs, algorithms, and current status must be updated in the same change as behavior.
 - The Sphinx docs site must remain buildable into HTML and PDF artifacts from repository sources.

--- a/docs/usage_commands.md
+++ b/docs/usage_commands.md
@@ -100,6 +100,70 @@ microseg-cli infer \
 
 Outputs are written under a dedicated run folder and include the input image, predicted mask, overlays, metrics, and a manifest.
 
+Run recursive folder inference (CLI) with machine-ingestible outputs:
+
+```bash
+microseg-cli infer \
+  --config configs/inference.default.yml \
+  --image-dir data/sample_images \
+  --recursive \
+  --glob-patterns "*.png,*.tif,*.tiff,*.jpg,*.jpeg"
+```
+
+Folder-mode export now writes:
+
+- `batch_results_summary.json` (machine-ingestible summary)
+- `batch_results_report.html` (input/mask/overlay per-row + key metrics)
+- `batch_metrics.csv`
+- `artifacts_manifest.json` (sha256 + size for generated artifacts)
+- `preview_images/` thumbnails for report rows
+- `runs/` per-image run folders (`input.png`, `prediction.png`, `overlay.png`, `metrics.json`, `manifest.json`)
+
+Recommended config keys for folder mode:
+
+```yaml
+image_dir: data/sample_images
+recursive: true
+glob_patterns: "*.png,*.tif,*.tiff,*.jpg,*.jpeg"
+model_name: Hydride Conventional
+output_dir: outputs/inference
+```
+
+### CLI import-error troubleshooting (`src` package not found)
+
+If you see errors like `ModuleNotFoundError: No module named 'src'`, use one of these supported run paths:
+
+1. **Install editable package (recommended):**
+
+```bash
+python -m pip install -e .
+microseg-cli infer --config configs/inference.default.yml --image test_data/syntheticHydrides.png
+```
+
+2. **Run module form from repository root:**
+
+```bash
+python -m scripts.microseg_cli infer --config configs/inference.default.yml --image test_data/syntheticHydrides.png
+```
+
+3. **Set `PYTHONPATH` explicitly (shell session only):**
+
+```bash
+export PYTHONPATH="$PWD:$PYTHONPATH"
+microseg-cli models --details
+```
+
+Verification checklist:
+
+- confirm current directory is repository root (`pwd`)
+- confirm interpreter is expected (`which python`)
+- confirm CLI entry point resolves (`which microseg-cli`)
+- smoke check imports:
+
+```bash
+python -c "import src.microseg, scripts.microseg_cli; print('ok')"
+```
+
 If you are integrating a new trained model into the GUI, review:
 
 - [`docs/gui_model_integration_guide.md`](gui_model_integration_guide.md)

--- a/hydride_segmentation/qt/main_window.py
+++ b/hydride_segmentation/qt/main_window.py
@@ -350,6 +350,187 @@ class ZoomableImageViewport(QWidget):
         self.zoom_label.setText(f"{int(round(self._zoom * 100))}%")
 
 
+class BatchResultsInspectorDialog(QDialog):
+    """Interactive viewer for batch_results_summary exports."""
+
+    def __init__(self, summary_path: str | Path, parent=None) -> None:
+        super().__init__(parent)
+        self.summary_path = Path(summary_path).expanduser().resolve()
+        self.batch_root = self.summary_path.parent
+        self.payload = self._load_summary()
+        self.rows: list[dict[str, object]] = [
+            row for row in self.payload.get("rows", []) if isinstance(row, dict)
+        ]
+        self.setWindowTitle(f"Batch Results Inspector — {self.summary_path.name}")
+        self.resize(1520, 920)
+
+        root = QVBoxLayout(self)
+        self.summary_label = QLabel(self._summary_text())
+        self.summary_label.setWordWrap(True)
+        root.addWidget(self.summary_label)
+
+        main_split = QSplitter(Qt.Horizontal)
+        root.addWidget(main_split, stretch=1)
+
+        left = QWidget()
+        left_layout = QVBoxLayout(left)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+        left_layout.addWidget(QLabel("Per-image runs"))
+        self.rows_table = QTableWidget(0, 5)
+        self.rows_table.setHorizontalHeaderLabels(["Image", "Model", "Area % (corr)", "Count (corr)", "Run ID"])
+        self.rows_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.rows_table.setSelectionMode(QAbstractItemView.SingleSelection)
+        self.rows_table.setEditTriggers(QAbstractItemView.NoEditTriggers)
+        self.rows_table.horizontalHeader().setStretchLastSection(True)
+        self.rows_table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeToContents)
+        left_layout.addWidget(self.rows_table, stretch=1)
+        main_split.addWidget(left)
+
+        right = QWidget()
+        right_layout = QVBoxLayout(right)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        self.preview_split = QSplitter(Qt.Horizontal)
+        self.input_view = ZoomableImageViewport("Input")
+        self.mask_view = ZoomableImageViewport("Mask")
+        self.overlay_view = ZoomableImageViewport("Overlay")
+        self.preview_split.addWidget(self.input_view)
+        self.preview_split.addWidget(self.mask_view)
+        self.preview_split.addWidget(self.overlay_view)
+        right_layout.addWidget(self.preview_split, stretch=4)
+
+        self.detail_text = QPlainTextEdit()
+        self.detail_text.setReadOnly(True)
+        self.detail_text.setPlaceholderText("Select a run row to view per-image statistics and provenance.")
+        right_layout.addWidget(self.detail_text, stretch=2)
+        main_split.addWidget(right)
+        main_split.setSizes([460, 1060])
+        self.preview_split.setSizes([360, 360, 360])
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Close)
+        buttons.rejected.connect(self.reject)
+        buttons.accepted.connect(self.accept)
+        root.addWidget(buttons)
+
+        self._populate_rows_table()
+        self.rows_table.itemSelectionChanged.connect(self._on_selection_changed)
+        if self.rows:
+            self.rows_table.selectRow(0)
+            self._show_row(0)
+
+    def _load_summary(self) -> dict[str, object]:
+        if not self.summary_path.exists():
+            raise FileNotFoundError(f"summary JSON not found: {self.summary_path}")
+        payload = json.loads(self.summary_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"summary JSON must be object: {self.summary_path}")
+        return payload
+
+    def _summary_text(self) -> str:
+        aggregate = self.payload.get("aggregate_metrics", [])
+        aggregate_rows = [row for row in aggregate if isinstance(row, dict)]
+        top_metrics = []
+        for row in aggregate_rows[:4]:
+            top_metrics.append(
+                f"{row.get('metric', '')}: mean={row.get('mean', '')} median={row.get('median', '')}"
+            )
+        top_line = " | ".join(top_metrics) if top_metrics else "n/a"
+        return (
+            f"Batch ID: {self.payload.get('batch_id', '')}    "
+            f"Runs: {self.payload.get('run_count', 0)}    "
+            f"Annotator: {self.payload.get('annotator', '')}\n"
+            f"Summary: {top_line}"
+        )
+
+    @staticmethod
+    def _as_display(value: object) -> str:
+        if isinstance(value, float):
+            return f"{value:.6g}"
+        if value is None:
+            return ""
+        return str(value)
+
+    def _row_metric(self, row: dict[str, object], key: str, fallback: str = "") -> str:
+        if key in row:
+            return self._as_display(row.get(key))
+        if fallback and fallback in row:
+            return self._as_display(row.get(fallback))
+        return ""
+
+    def _populate_rows_table(self) -> None:
+        self.rows_table.setRowCount(len(self.rows))
+        for idx, row in enumerate(self.rows):
+            values = [
+                str(row.get("image_name", row.get("image_path", ""))),
+                str(row.get("model_name", "")),
+                self._row_metric(row, "corrected_hydride_area_fraction_percent", "predicted_hydride_area_fraction_percent"),
+                self._row_metric(row, "corrected_hydride_count", "predicted_hydride_count"),
+                str(row.get("run_id", "")),
+            ]
+            for col, value in enumerate(values):
+                self.rows_table.setItem(idx, col, QTableWidgetItem(value))
+
+    def _resolve_image_path(self, row: dict[str, object], key: str, fallback_name: str) -> Path | None:
+        rel = str(row.get(key, "")).strip()
+        if rel:
+            path = (self.batch_root / rel).resolve()
+            if path.exists():
+                return path
+        run_id = str(row.get("run_id", "")).strip()
+        if run_id:
+            run_dirs = sorted((self.batch_root / "runs").glob(f"*_{run_id}"))
+            if run_dirs:
+                candidate = run_dirs[0] / fallback_name
+                if candidate.exists():
+                    return candidate.resolve()
+        return None
+
+    def _set_view_from_path(self, view: ZoomableImageViewport, image_path: Path | None) -> None:
+        if image_path is None:
+            view.image_label.setText("n/a")
+            view.zoom_label.setText("0%")
+            return
+        try:
+            with Image.open(image_path) as img:
+                view.set_image(np.array(img))
+        except Exception:
+            view.image_label.setText(f"Failed to load\n{image_path.name}")
+            view.zoom_label.setText("0%")
+
+    def _on_selection_changed(self) -> None:
+        rows = self.rows_table.selectionModel().selectedRows()
+        if not rows:
+            return
+        self._show_row(int(rows[0].row()))
+
+    def _show_row(self, idx: int) -> None:
+        if idx < 0 or idx >= len(self.rows):
+            return
+        row = self.rows[idx]
+        input_path = self._resolve_image_path(row, "input_preview_path", "input.png")
+        mask_path = self._resolve_image_path(row, "mask_preview_path", "prediction.png")
+        overlay_path = self._resolve_image_path(row, "overlay_preview_path", "overlay.png")
+        self._set_view_from_path(self.input_view, input_path)
+        self._set_view_from_path(self.mask_view, mask_path)
+        self._set_view_from_path(self.overlay_view, overlay_path)
+
+        metric_lines = []
+        for key in sorted(k for k in row.keys() if str(k).startswith(("predicted_", "corrected_"))):
+            metric_lines.append(f"{key}: {self._as_display(row.get(key))}")
+        detail = [
+            f"image_name: {row.get('image_name', '')}",
+            f"image_path: {row.get('image_path', '')}",
+            f"run_id: {row.get('run_id', '')}",
+            f"model_name: {row.get('model_name', '')}",
+            f"model_id: {row.get('model_id', '')}",
+            f"started_utc: {row.get('started_utc', '')}",
+            f"finished_utc: {row.get('finished_utc', '')}",
+            "",
+            "metrics:",
+            *metric_lines,
+        ]
+        self.detail_text.setPlainText("\n".join(detail))
+
+
 class CalibrationLineCanvas(QLabel):
     """Simple interactive canvas for drawing one calibration line."""
 
@@ -1486,6 +1667,9 @@ class QtSegmentationMainWindow(QMainWindow):
         act_export_batch_results = QAction("Export Batch Summary", self)
         act_export_batch_results.triggered.connect(self.on_export_batch_results)
         file_menu.addAction(act_export_batch_results)
+        act_open_batch_results = QAction("Open Batch Results Summary...", self)
+        act_open_batch_results.triggered.connect(self.on_open_batch_results_summary)
+        file_menu.addAction(act_open_batch_results)
 
         act_export = QAction("Export Corrected Sample", self)
         act_export.triggered.connect(self.on_export_correction)
@@ -2151,6 +2335,9 @@ class QtSegmentationMainWindow(QMainWindow):
         self.btn_results_export = QPushButton("Export Results")
         self.btn_results_export.clicked.connect(self.on_export_results_package)
         results_controls.addWidget(self.btn_results_export)
+        self.btn_results_open_batch = QPushButton("Open Batch Summary")
+        self.btn_results_open_batch.clicked.connect(self.on_open_batch_results_summary)
+        results_controls.addWidget(self.btn_results_open_batch)
         results_controls.addStretch(1)
 
         self.results_summary_label = QLabel("Results: run segmentation to populate dashboard")
@@ -4620,12 +4807,27 @@ class QtSegmentationMainWindow(QMainWindow):
             QMessageBox.critical(self, "Segmentation Error", str(exc))
 
     def on_run_batch(self) -> None:
-        paths, _ = QFileDialog.getOpenFileNames(
-            self,
-            "Select batch images",
-            "",
-            "Images (*.png *.jpg *.jpeg *.tif *.tiff *.bmp)",
-        )
+        selected_dir = QFileDialog.getExistingDirectory(self, "Select input folder for recursive batch inference")
+        if not selected_dir:
+            paths, _ = QFileDialog.getOpenFileNames(
+                self,
+                "Select batch images",
+                "",
+                "Images (*.png *.jpg *.jpeg *.tif *.tiff *.bmp)",
+            )
+        else:
+            cfg = self._resolve_run_config()
+            recursive = bool(cfg.get("recursive", True))
+            patterns_text = str(cfg.get("glob_patterns", "*.png,*.jpg,*.jpeg,*.tif,*.tiff,*.bmp"))
+            patterns = [item.strip() for item in patterns_text.replace("|", ",").split(",") if item.strip()]
+            root = Path(selected_dir)
+            scanner = root.rglob if recursive else root.glob
+            found: list[str] = []
+            for pattern in patterns:
+                for path in scanner(pattern):
+                    if path.is_file():
+                        found.append(str(path))
+            paths = sorted(set(found))
         if not paths:
             return
         self.state.image_path = str(paths[0])
@@ -5076,9 +5278,29 @@ class QtSegmentationMainWindow(QMainWindow):
                 ",".join(self._selected_report_sections()),
             )
             QMessageBox.information(self, "Batch Results Exported", f"Saved batch results package:\n{export_dir}")
+            self._open_batch_results_summary_path(Path(export_dir) / "batch_results_summary.json")
         except Exception as exc:
             self.logger.exception("Batch results package export failed")
             QMessageBox.critical(self, "Batch Results Export Error", str(exc))
+
+    def _open_batch_results_summary_path(self, summary_path: Path) -> None:
+        try:
+            dialog = BatchResultsInspectorDialog(summary_path, parent=self)
+            dialog.exec()
+        except Exception as exc:
+            self.logger.exception("Failed to open batch results summary: %s", summary_path)
+            QMessageBox.critical(self, "Batch Summary Viewer Error", str(exc))
+
+    def on_open_batch_results_summary(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open batch_results_summary.json",
+            "",
+            "JSON (*.json)",
+        )
+        if not path:
+            return
+        self._open_batch_results_summary_path(Path(path))
 
     def on_open_appearance_settings(self) -> None:
         dialog = AppearanceExportSettingsDialog(

--- a/scripts/microseg_cli.py
+++ b/scripts/microseg_cli.py
@@ -14,6 +14,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from src.microseg.app.desktop_workflow import DesktopWorkflowManager
+from src.microseg.app.desktop_result_export import DesktopResultExportConfig, DesktopResultExporter
 from src.microseg.app.hpc_ga import (
     HpcGaPlanConfig,
     generate_hpc_ga_bundle,
@@ -188,11 +189,56 @@ def _build_dataset_prepare_config(
     )
 
 
+def _collect_inference_images(
+    *,
+    image: str | None,
+    image_dir: str | None,
+    glob_patterns: list[str],
+    recursive: bool,
+) -> list[Path]:
+    candidates: list[Path] = []
+    if str(image or "").strip():
+        candidates.append(Path(str(image)).expanduser().resolve())
+    if str(image_dir or "").strip():
+        root = Path(str(image_dir)).expanduser().resolve()
+        if not root.exists():
+            raise FileNotFoundError(f"image directory does not exist: {root}")
+        if not root.is_dir():
+            raise NotADirectoryError(f"image directory is not a directory: {root}")
+        patterns = [p.strip() for p in glob_patterns if p and p.strip()]
+        if not patterns:
+            patterns = ["*.png", "*.jpg", "*.jpeg", "*.bmp", "*.tif", "*.tiff"]
+        scanner = root.rglob if recursive else root.glob
+        for pattern in patterns:
+            candidates.extend(scanner(pattern))
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in sorted(candidates):
+        key = str(path.resolve())
+        if key in seen:
+            continue
+        seen.add(key)
+        if path.is_file():
+            unique.append(path)
+    return unique
+
+
 def _infer(args: argparse.Namespace) -> int:
     cfg = resolve_config(args.config, args.set)
     image_path = args.image or cfg.get("image_path")
-    if not image_path:
-        raise ValueError("image path is required (--image or config:image_path)")
+    image_dir = args.image_dir or cfg.get("image_dir")
+    recursive = bool(cfg.get("recursive", args.recursive))
+    patterns = _parse_name_list(cfg.get("glob_patterns", args.glob_patterns))
+    image_paths = _collect_inference_images(
+        image=str(image_path) if image_path else None,
+        image_dir=str(image_dir) if image_dir else None,
+        glob_patterns=patterns,
+        recursive=recursive,
+    )
+    if not image_paths:
+        raise ValueError(
+            "no input images found; set --image or --image-dir (with optional --glob-patterns/--recursive)"
+        )
 
     model_name = args.model_name or cfg.get("model_name")
     if not model_name:
@@ -205,27 +251,36 @@ def _infer(args: argparse.Namespace) -> int:
     params["device_policy"] = str(cfg.get("device_policy", args.device_policy))
 
     mgr = DesktopWorkflowManager()
-    record = mgr.run_single(
-        str(image_path),
+    records = mgr.run_batch(
+        [str(p) for p in image_paths],
         model_name=model_name,
         params=params,
         include_analysis=include_analysis,
     )
+    if not records:
+        raise RuntimeError("inference returned no records")
 
     capture_feedback = bool(cfg.get("capture_feedback", args.capture_feedback))
+    feedback_writer: FeedbackArtifactWriter | None = None
     if capture_feedback:
-        feedback_capture = FeedbackArtifactWriter(
+        feedback_writer = FeedbackArtifactWriter(
             FeedbackCaptureConfig(
                 feedback_root=str(cfg.get("feedback_root", args.feedback_root or "outputs/feedback_records")),
                 deployment_id=str(cfg.get("deployment_id", args.deployment_id or "cli_infer")),
                 operator_id=str(cfg.get("operator_id", args.operator_id or "unknown_operator")),
                 source="cli_infer",
             )
-        ).create_from_desktop_run(
+        )
+    for record in records:
+        if feedback_writer is None:
+            continue
+        row_params = dict(params)
+        row_params["image_path"] = str(record.image_path)
+        feedback_capture = feedback_writer.create_from_desktop_run(
             record,
             source="cli_infer",
             resolved_config=cfg,
-            params=params,
+            params=row_params,
             runtime={
                 "enable_gpu": bool(params.get("enable_gpu", False)),
                 "device_policy": str(params.get("device_policy", args.device_policy)),
@@ -235,11 +290,22 @@ def _infer(args: argparse.Namespace) -> int:
         record.feedback_record_dir = str(feedback_capture.record_dir)
         record.feedback_record_id = str(feedback_capture.record_id)
 
-    run_dir = mgr.export_run(record, out_dir)
-    (run_dir / "resolved_config.json").write_text(json.dumps(cfg, indent=2), encoding="utf-8")
-    print(f"inference export: {run_dir}")
-    if record.feedback_record_dir:
-        print(f"feedback record: {record.feedback_record_dir}")
+    exporter = DesktopResultExporter()
+    batch_dir = exporter.export_batch(
+        records,
+        output_dir=out_dir,
+        annotator=str(cfg.get("operator_id", args.operator_id or "unknown_operator")),
+        notes=str(cfg.get("batch_notes", "")),
+        config=DesktopResultExportConfig(write_batch_summary=True),
+    )
+    runs_dir = batch_dir / "runs"
+    for record in records:
+        mgr.export_run(record, runs_dir)
+    (batch_dir / "resolved_config.json").write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    print(f"inference export: {batch_dir}")
+    print(f"inference image count: {len(records)}")
+    if capture_feedback:
+        print("feedback capture: enabled")
     return 0
 
 
@@ -1649,6 +1715,19 @@ def _build_parser() -> argparse.ArgumentParser:
     infer.add_argument("--config", type=str, help="YAML config path")
     infer.add_argument("--set", action="append", default=[], help="Override key=value (supports dotted keys)")
     infer.add_argument("--image", type=str, help="Input image path")
+    infer.add_argument("--image-dir", type=str, default="", help="Input image directory (supports recursive scan)")
+    infer.add_argument(
+        "--glob-patterns",
+        type=str,
+        default="*.png,*.jpg,*.jpeg,*.bmp,*.tif,*.tiff",
+        help="Comma-separated glob patterns used with --image-dir",
+    )
+    infer.add_argument(
+        "--recursive",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Recursively scan sub-directories when --image-dir is set",
+    )
     infer.add_argument("--model-name", type=str, help="Model display name from registry")
     infer.add_argument("--output-dir", type=str, help="Export output directory")
     infer.add_argument("--enable-gpu", action="store_true", help="Enable GPU auto-selection for ML inference")

--- a/src/microseg/app/desktop_result_export.py
+++ b/src/microseg/app/desktop_result_export.py
@@ -966,6 +966,23 @@ class DesktopResultExporter:
         summary_path = batch_dir / "batch_results_summary.json"
         summary_path.write_text(json.dumps(summary_payload, indent=2), encoding="utf-8")
 
+        preview_dir = batch_dir / "preview_images"
+        preview_dir.mkdir(parents=True, exist_ok=True)
+        for idx, run in enumerate(runs, start=1):
+            stem = f"{idx:04d}_{Path(run.image_name).stem}"
+            input_path = preview_dir / f"{stem}_input.png"
+            mask_path = preview_dir / f"{stem}_mask.png"
+            overlay_path = preview_dir / f"{stem}_overlay.png"
+            run.input_image.save(input_path)
+            run.mask_image.save(mask_path)
+            run.overlay_image.save(overlay_path)
+            if idx - 1 < len(summary_payload["rows"]):
+                summary_payload["rows"][idx - 1]["input_preview_path"] = _to_rel(input_path, batch_dir)
+                summary_payload["rows"][idx - 1]["mask_preview_path"] = _to_rel(mask_path, batch_dir)
+                summary_payload["rows"][idx - 1]["overlay_preview_path"] = _to_rel(overlay_path, batch_dir)
+
+        summary_path.write_text(json.dumps(summary_payload, indent=2), encoding="utf-8")
+
         if bool(cfg.write_csv_report):
             csv_path = batch_dir / "batch_metrics.csv"
             all_fields: list[str] = []
@@ -987,6 +1004,29 @@ class DesktopResultExporter:
             pdf_path = batch_dir / "batch_results_report.pdf"
             self._write_batch_pdf(pdf_path=pdf_path, payload=summary_payload)
 
+        if bool(cfg.include_artifact_manifest):
+            rows_manifest: list[dict[str, Any]] = []
+            for path in sorted(p for p in batch_dir.rglob("*") if p.is_file() and p.name != "artifacts_manifest.json"):
+                rows_manifest.append(
+                    {
+                        "path": _to_rel(path, batch_dir),
+                        "size_bytes": int(path.stat().st_size),
+                        "sha256": _sha256_file(path),
+                    }
+                )
+            (batch_dir / "artifacts_manifest.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": "microseg.desktop_batch_artifacts_manifest.v1",
+                        "created_utc": _utc_now(),
+                        "file_count": len(rows_manifest),
+                        "files": rows_manifest,
+                    },
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+
         return batch_dir
 
     @staticmethod
@@ -998,14 +1038,30 @@ class DesktopResultExporter:
             if not isinstance(row, dict):
                 continue
             for key in row.keys():
+                if key in {"input_preview_path", "mask_preview_path", "overlay_preview_path"}:
+                    continue
                 if key not in header_fields:
                     header_fields.append(key)
         run_rows = []
         for row in rows if isinstance(rows, list) else []:
             if not isinstance(row, dict):
                 continue
+            metric_bits = []
+            for key in (
+                "corrected_hydride_area_fraction_percent",
+                "predicted_hydride_area_fraction_percent",
+                "corrected_hydride_count",
+                "predicted_hydride_count",
+            ):
+                if key in row:
+                    metric_bits.append(f"{html.escape(key)}={html.escape(_fmt_metric(row.get(key, '')))}")
+            metrics_inline = "<br/>".join(metric_bits) if metric_bits else "n/a"
             run_rows.append(
                 "<tr>"
+                f"<td><img src='{html.escape(str(row.get('input_preview_path', '')))}' alt='input' style='max-width:220px;max-height:140px;'/></td>"
+                f"<td><img src='{html.escape(str(row.get('mask_preview_path', '')))}' alt='mask' style='max-width:220px;max-height:140px;'/></td>"
+                f"<td><img src='{html.escape(str(row.get('overlay_preview_path', '')))}' alt='overlay' style='max-width:220px;max-height:140px;'/></td>"
+                f"<td>{metrics_inline}</td>"
                 + "".join(f"<td>{html.escape(_fmt_metric(row.get(k, '')))}</td>" for k in header_fields)
                 + "</tr>"
             )
@@ -1046,6 +1102,7 @@ class DesktopResultExporter:
             f"<tbody>{''.join(agg_rows) if agg_rows else '<tr><td colspan=7>n/a</td></tr>'}</tbody></table>"
             "<h2>Run Rows</h2>"
             "<table><thead><tr>"
+            "<th>Input</th><th>Mask</th><th>Overlay</th><th>Key Stats</th>"
             + "".join(f"<th>{html.escape(field)}</th>" for field in header_fields)
             + "</tr></thead><tbody>"
             + ("".join(run_rows) if run_rows else "<tr><td>n/a</td></tr>")

--- a/tests/test_phase27_desktop_batch_export.py
+++ b/tests/test_phase27_desktop_batch_export.py
@@ -63,11 +63,16 @@ def test_phase27_batch_export_outputs(tmp_path: Path) -> None:
     assert (out_dir / "batch_results_summary.json").exists()
     assert (out_dir / "batch_results_report.html").exists()
     assert (out_dir / "batch_metrics.csv").exists()
+    assert (out_dir / "artifacts_manifest.json").exists()
+    assert (out_dir / "preview_images").exists()
     assert not (out_dir / "batch_results_report.pdf").exists()
 
     payload = json.loads((out_dir / "batch_results_summary.json").read_text(encoding="utf-8"))
     assert payload["schema_version"] == "microseg.desktop_batch_results.v1"
     assert int(payload["run_count"]) == 2
     assert len(payload["rows"]) == 2
+    assert all(str(row.get("input_preview_path", "")).startswith("preview_images/") for row in payload["rows"])
+    assert all(str(row.get("mask_preview_path", "")).startswith("preview_images/") for row in payload["rows"])
+    assert all(str(row.get("overlay_preview_path", "")).startswith("preview_images/") for row in payload["rows"])
     assert payload["aggregate_metrics"]
     assert "Hydride" in next(iter(payload["model_counts"].keys()))


### PR DESCRIPTION
### Motivation

- Provide parity between GUI and CLI for folder-scale (recursive) inference workflows and make per-image evidence easily inspectable for human review. 
- Improve batch exports to include machine-ingestible artifacts and thumbnail previews for rapid visual QA and downstream automation.
- Give desktop users an in-app inspector to review exported `batch_results_summary.json` with aligned input/mask/overlay previews and per-image metrics.

### Description

- Added recursive folder inference support to the CLI by introducing `--image-dir`, `--glob-patterns`, and `--recursive`, including `_collect_inference_images` and updated `infer` handler to run batch inference and export using `DesktopResultExporter` and `DesktopResultExportConfig`.
- Enhanced `DesktopResultExporter.export_batch` to create `preview_images/` (input/mask/overlay thumbnails), attach `input_preview_path`/`mask_preview_path`/`overlay_preview_path` to `batch_results_summary.json`, and optionally write `artifacts_manifest.json` with `sha256` and sizes when `include_artifact_manifest` is enabled.
- Augmented the HTML batch report to render row thumbnails and key inline metrics, and wrote the preview images into the batch folder.
- Added `BatchResultsInspectorDialog` GUI component and menu/button actions to open a `batch_results_summary.json` for interactive per-image inspection, including three `ZoomableImageViewport`s and a detailed metrics/provenance pane.
- Updated docs (`docs/*`) to document recursive folder inference, CLI troubleshooting (module import forms), batch export outputs, and GUI batch inspection flows.
- Updated CLI entrypoint import to include desktop export classes and adjusted feedback capture plumbing to create per-row feedback using updated parameters.

### Testing

- Ran the updated unit test `pytest tests/test_phase27_desktop_batch_export.py` which asserts that `batch_results_summary.json`, `batch_results_report.html`, `batch_metrics.csv`, `artifacts_manifest.json`, and `preview_images/` are produced and that preview paths are referenced in rows; the test passed.
- Ran the modified `infer` CLI path in a local smoke scenario to validate that a folder scan returns multiple records and that `DesktopResultExporter.export_batch` writes the `runs/` and `preview_images/` outputs successfully (smoke checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d88ca573f883249a7599d48d94ce17)